### PR TITLE
Fix tincr::sites::has_alternate_type

### DIFF
--- a/tincr/cad/device/sites.tcl
+++ b/tincr/cad/device/sites.tcl
@@ -225,7 +225,7 @@ proc ::tincr::sites::has_alternate_types { site } {
 		error "ERROR Expected one site object."
 	}
 	
-	if {[llength [sites get_alternate_types $site]] != 0} {
+	if {[llength [get_alternate_types $site]] != 0} {
 		return 1
 	}
 	


### PR DESCRIPTION
#1 The sites ensemble's has_alternate_types method makes a call to the get_alternate_types method. The method call got messed up during a refactoring, and is prefixed by the "sites" ensemble command. This is unnecessary since both methods live in the same ensemble.
