### PR TITLE
Mis-spelled connect_net procedure declarations

### DIFF
--- a/tincr/cad/design/pins.tcl
+++ b/tincr/cad/design/pins.tcl
@@ -75,6 +75,6 @@ proc ::tincr::pins::remove { pin } {
 ## Connect a pin to a net.
 # @param pin The <CODE>pin</CODE> object.
 # @param net The <CODE>net</CODE> object.
-proc ::tincr::pin::connect_net { pin net } {
+proc ::tincr::pins::connect_net { pin net } {
     connect_net -quiet -hierarchical -net $net $pin
 }

--- a/tincr/cad/design/ports.tcl
+++ b/tincr/cad/design/ports.tcl
@@ -41,6 +41,6 @@ proc ::tincr::ports::get { args } {
 ## Connect a port to a net.
 # @param port The <CODE>port</CODE> object.
 # @param net The <CODE>net</CODE> object.
-proc ::tincr::port::connect_net { port net } {
+proc ::tincr::ports::connect_net { port net } {
     connect_net -quiet -hierarchical -net $net $port
 }


### PR DESCRIPTION
pins.tcl and ports.tcl had incorrect definitions for their connect_net routines

Brad - how do we proceed now we have a pull request?
