### PR TITLE
Add LUT equation methods to ::tincr::cells ensemble

### DIFF
--- a/tincr/cad/design/cells.tcl
+++ b/tincr/cad/design/cells.tcl
@@ -377,7 +377,7 @@ proc ::tincr::cells::set_lut_eqn { cell equation } {
     }
     
     set num_inputs [llength [get_input_pins $cell]]
-    set num_combinations [expr 2**$num_inputs]
+    set num_combinations [expr 1 << $num_inputs]
     
     # Legal Operator Set:
     #   XOR: @ ^

--- a/tincr/cad/design/cells.tcl
+++ b/tincr/cad/design/cells.tcl
@@ -416,7 +416,7 @@ proc ::tincr::cells::set_lut_eqn { cell equation } {
     #   AND: * & .
     #   OR:  + |
     #   NOT: ~ !
-    set formatted_equation [string map {@ ^ * & . & + | ! ~ I $I O= ""} $equation]
+    set formatted_equation [string map {@ ^ * & . & + | ! ~ I $I O "" = ""} $equation]
     
     set result 0
     for {set cnt 0} {$cnt < $num_combinations} {incr cnt} {

--- a/tincr/cad/design/cells.tcl
+++ b/tincr/cad/design/cells.tcl
@@ -400,5 +400,5 @@ proc ::tincr::cells::set_lut_eqn { cell equation } {
     }
     
     # Format $result as a hexadecimal number that Vivado will accept.
-    set_property INIT "$num_combinations'h[format %[expr $num_combinations / 4]X $result]" $cell
+    set_property INIT "$num_combinations'h[format %[expr $num_combinations >> 2]X $result]" $cell
 }

--- a/tincr/cad/design/cells.tcl
+++ b/tincr/cad/design/cells.tcl
@@ -27,14 +27,19 @@ namespace eval ::tincr::cells {
         get_name \
         get_type \
         get_primitives \
+        get_input_pins \
+        get_output_pins \
         is_placed \
         is_placement_legal \
+        is_lut \
         compatible_with \
         place \
         unplace \
         duplicate \
         insert \
-        tie_unused_pins
+        tie_unused_pins \
+        get_lut_eqn \
+        set_lut_eqn
     namespace ensemble create
 }
 
@@ -157,6 +162,20 @@ proc ::tincr::cells::get_primitives {} {
     return [get_cells -hierarchical -filter {PRIMITIVE_LEVEL==LEAF || PRIMITIVE_LEVEL==INTERNAL}]
 }
 
+## Get a cell's input pins.
+# @param cell The <CODE>cell</CODE> object.
+# @return The input pins of <CODE>cell</CODE>.
+proc ::tincr::cells::get_input_pins { cell } {
+    return [get_pins -quiet -of_objects $cell -filter {DIRECTION==IN}]
+}
+
+## Get a cell's output pins.
+# @param cell The <CODE>cell</CODE> object.
+# @return The output pins of <CODE>cell</CODE>.
+proc ::tincr::cells::get_output_pins { cell } {
+    return [get_pins -quiet -of_objects $cell -filter {DIRECTION==OUT}]
+}
+
 ## Is this cell placed?
 # @param cell The <CODE>cell</CODE> object.
 # @return TRUE (1) if cell is placed, FALSE (0) otherwise.
@@ -177,6 +196,17 @@ proc ::tincr::cells::is_placed { cell } {
 proc ::tincr::cells::is_placement_legal { cell bel } {
     if {[catch {place_cell [get_name $cell] [::tincr::get_name $bel]} fid] == 0} {
         unplace_cell [get_name $cell]
+        return 1
+    }
+    
+    return 0
+}
+
+## Is this cell a LUT?
+# @param cell The cell to test.
+# @return True (1) if <CODE>cell</CODE> is a LUT, false (0) otherwise.
+proc ::tincr::cells::is_lut { cell } {
+    if {[get_property PRIMITIVE_GROUP $cell] == "LUT"} {
         return 1
     }
     
@@ -329,4 +359,46 @@ proc ::tincr::cells::insert { cell net {sinks ""} {inpin ""} {outpin ""} {downhi
 # @param cell The <CODE>cell</CODE> object whose pins should be tied.
 proc ::tincr::cells::tie_unused_pins { cell } {
     tie_unused_pins -of_objects $cell
+}
+
+## Get the LUT's equation in sum-of-products form.
+# @param cell The cells whose equation you wish to retrieve.
+# @return The LUT's equation in sum-of-products form.
+proc ::tincr::cells::get_lut_eqn { cell } {
+    
+}
+
+## Set the LUT's equation.
+# @param cell The cell whose equation you wish to set.
+# @param equation The equation to set. Use I0, I1, etc. as inputs and O as the output. i.e. O=I0&~I1|(I1*I2).
+proc ::tincr::cells::set_lut_eqn { cell equation } {
+    if {[is_lut $cell] == 0} {
+        return
+    }
+    
+    set num_inputs [llength [get_input_pins $cell]]
+    set num_combinations [expr 2**$num_inputs]
+    
+    # Legal Operator Set:
+    #   XOR: @ ^
+    #   AND: * & .
+    #   OR:  + |
+    #   NOT: ~ !
+    set formatted_equation [string map {@ ^ * & . & + | ! ~ I $I O= ""} $equation]
+    
+    set result 0
+    for {set cnt 0} {$cnt < $num_combinations} {incr cnt} {
+        # Set the inputs
+        for {set i 0} {$i < $num_inputs} {incr i} {
+            set "I$i" [expr ($cnt >> $i) & 1]
+        }
+        
+        # If this equation equates as true, prepend a '1' to the beginning of $result
+        if {[expr $formatted_equation]} {
+            incr result [expr 1 << $cnt]
+        }
+    }
+    
+    # Format $result as a hexadecimal number that Vivado will accept.
+    set_property INIT "$num_combinations'h[format %[expr $num_combinations / 4]X $result]" $cell
 }

--- a/tincr/cad/design/lib_cells.tcl
+++ b/tincr/cad/design/lib_cells.tcl
@@ -10,105 +10,117 @@ package require struct 2.1
 
 ## @brief All of the Tcl procs provided in the design package are members of the <CODE>::tincr</CODE> namespace.
 namespace eval ::tincr {
-	namespace export lib_cells
+    namespace export lib_cells
 }
 
 ## @brief The <CODE>lib_cells</CODE> ensemble encapsulates the <CODE>lib_cell</CODE> class from Vivado's Tcl data structure.
 namespace eval ::tincr::lib_cells {
-	namespace export \
-		test \
-		test_proc \
-		get \
-		compatible_with
-	namespace ensemble create
+    namespace export \
+        test \
+        test_proc \
+        get \
+        compatible_with \
+        is_lut
+    namespace ensemble create
 }
 
 ## Executes all unit tests for every proc in the <CODE>lib_cells</CODE> ensemble.
 # @param args The configuration arguments that will be passed to the <CODE>tcltest</CODE> unit testing suite.
 proc ::tincr::lib_cells::test {args} {
-	source_with_args [file join $::env(TINCR_PATH) tincr_test cad design lib_cells all.tcl] {*}$args
+    source_with_args [file join $::env(TINCR_PATH) tincr_test cad design lib_cells all.tcl] {*}$args
 }
 
 ## Executes all unit tests for a particular proc in the <CODE>lib_cells</CODE> ensemble.
 # @param proc The proc to run the unit tests for.
 # @param args The configuration arguments that will be passed to the <CODE>tcltest</CODE> unit testing suite.
 proc ::tincr::lib_cells::test_proc {proc args} {
-	exec [file join $::env(TINCR_PATH) interpreter windows vivado_tclsh.bat] [file join $::env(TINCR_PATH) tincr_test cad design lib_cells "$proc.test"] {*}$args
+    exec [file join $::env(TINCR_PATH) interpreter windows vivado_tclsh.bat] [file join $::env(TINCR_PATH) tincr_test cad design lib_cells "$proc.test"] {*}$args
 }
 
 ## Queries Vivado's object database for a list of <CODE>lib_cell</CODE> objects that fit the given criteria. This is mostly a wrapper function for Vivado's <CODE>get_lib_cells</CODE> command, though it does add additional features (such as getting the library cells of an architecture).
 proc ::tincr::lib_cells::get { args } {
-	set regexp 0
-	set nocase 0
-	set quiet 0
-	set verbose 0
-	::tincr::parse_args {architecture filter range of_objects} {regexp nocase quiet verbose} {patterns} {} $args
-	
-	set arguments [list]
-	
-	if {[info exists filter]} {
-		lappend arguments "-filter" $filter
-	}
-	if {[info exists range]} {
-		lappend arguments "-range" $range
-	}
-	if {[info exists of_objects]} {
-		lappend arguments "-of_objects" $of_objects
-	}
-	if {$regexp} {
-		lappend arguments "-regexp"
-	}
-	if {$nocase} {
-		lappend arguments "-nocase"
-	}
-	if {$quiet} {
-		lappend arguments "-quiet"
-	}
-	if {$verbose} {
-		lappend arguments "-verbose"
-	}
-	if {[info exists patterns]} {
-		lappend arguments $patterns
-	}
-	
-	set lib_cells [get_lib_cells {*}$arguments]
-	
-	if {[info exists architecture]} {
-		set lib_cells [::struct::set intersect $lib_cells [get_lib_cells -regexp -filter "SUPPORTED_ARCHITECTURES=~\"ALL|\(\(^|\(.+ \)\)$architecture\(\( .+\)|\$)\)\""]]
-	}
-	
-	return $lib_cells
+    set regexp 0
+    set nocase 0
+    set quiet 0
+    set verbose 0
+    ::tincr::parse_args {architecture filter range of_objects} {regexp nocase quiet verbose} {patterns} {} $args
+    
+    set arguments [list]
+    
+    if {[info exists filter]} {
+        lappend arguments "-filter" $filter
+    }
+    if {[info exists range]} {
+        lappend arguments "-range" $range
+    }
+    if {[info exists of_objects]} {
+        lappend arguments "-of_objects" $of_objects
+    }
+    if {$regexp} {
+        lappend arguments "-regexp"
+    }
+    if {$nocase} {
+        lappend arguments "-nocase"
+    }
+    if {$quiet} {
+        lappend arguments "-quiet"
+    }
+    if {$verbose} {
+        lappend arguments "-verbose"
+    }
+    if {[info exists patterns]} {
+        lappend arguments $patterns
+    }
+    
+    set lib_cells [get_lib_cells {*}$arguments]
+    
+    if {[info exists architecture]} {
+        set lib_cells [::struct::set intersect $lib_cells [get_lib_cells -regexp -filter "SUPPORTED_ARCHITECTURES=~\"ALL|\(\(^|\(.+ \)\)$architecture\(\( .+\)|\$)\)\""]]
+    }
+    
+    return $lib_cells
 }
 
 ## Get the library cells that are compatible for placement on or within the given objects.
 # @param objs The object or list of objects. Legal objects include <CODE>bel</CODE>, <CODE>site</CODE>, and <CODE>tile</CODE> objects.
 # @return A list of library cells that may be placed on or within the given object(s).
 proc ::tincr::lib_cells::compatible_with {objs} {
-	::set result {}
-	if {[llength $objs] == 1} {
-		set objs [list $objs]
-	}
-	
-	foreach obj $objs {
-		switch [::tincr::get_class $obj] {
-			tile {
-				foreach site [get_sites -of_object $obj] {
-					::struct::set add result [compatible_with $site]
-				}
-			}
-			site {
-				foreach bel [get_bels -of_objects $obj] {
-					::struct::set add result [compatible_with $bel]
-				}
-			}
-			bel {
-				::tincr::cache::get array.bel_type.lib_cells beltype2libcells
-				if {[info exists beltype2libcells([::tincr::get_type $obj])]} {
-					::struct::set add result $beltype2libcells([::tincr::get_type $obj])
-				}
-			}
-		}
-	}
-	
-	return $result
+    ::set result {}
+    if {[llength $objs] == 1} {
+        set objs [list $objs]
+    }
+    
+    foreach obj $objs {
+        switch [::tincr::get_class $obj] {
+            tile {
+                foreach site [get_sites -of_object $obj] {
+                    ::struct::set add result [compatible_with $site]
+                }
+            }
+            site {
+                foreach bel [get_bels -of_objects $obj] {
+                    ::struct::set add result [compatible_with $bel]
+                }
+            }
+            bel {
+                ::tincr::cache::get array.bel_type.lib_cells beltype2libcells
+                if {[info exists beltype2libcells([::tincr::get_type $obj])]} {
+                    ::struct::set add result $beltype2libcells([::tincr::get_type $obj])
+                }
+            }
+        }
+    }
+    
+    return $result
+}
+
+## Is this library cell a LUT?
+# @param lib_cell The library cell to test.
+# @return True (1) if <CODE>lib_cell</CODE> is a LUT, false (0) otherwise.
+proc ::tincr::lib_cells::is_lut { lib_cell } {
+    if {[get_property PRIMITIVE_GROUP $lib_cell] == "LUT"} {
+        return 1
+    }
+    
+    return 0
 }

--- a/tincr_test/cad/design/cells/set_lut_eqn.test
+++ b/tincr_test/cad/design/cells/set_lut_eqn.test
@@ -1,0 +1,34 @@
+package require tcltest 2.2
+
+eval ::tcltest::configure $::argv
+
+package require tincr
+
+namespace eval ::tincr::cells::test {
+    namespace import ::tcltest::*
+    
+    set part [get_parts xc7k70tfbg484-2]
+    
+    variable SIMPLE_UNROUTED_DESIGN {
+        #common setup code
+        if {[get_part -quiet -of [current_project -quiet]] != $part} {
+            link_design -quiet -part $part
+        }
+    }
+    
+    variable CLEANUP {
+        #common cleanup code
+        close_project
+    }
+    
+    test set_lut_eqn-1 {Successfully set the equation of a LUT} -setup $SIMPLE_UNROUTED_DESIGN -body {
+        set cell [create_cell -reference LUT3 lut]
+        
+        tincr::cells set_lut_eqn $cell "O=I0&~I1|(I1*I2)"
+        
+        get_property INIT $cell
+    } -cleanup $CLEANUP -result {8'hE2}
+    
+    cleanupTests
+}
+namespace delete ::tincr::cells::test


### PR DESCRIPTION
Issue #11. Add some methods for setting and getting the LUT equation of a qualifying cell. This should make life a little bit easier for people who need to work with LUT equations.

Changes:
- The set_lut_eqn method actually evaluates the equation under every single permutation of input, and constructs a hex value that is then assigned to the cell's INIT property
- Added is_lut functions to cells and lib_cells ensembles
- Added get_input_pins and get_output_pins methods to cells
