### PR TITLE
Do not include excluded PIPs in XDLRC

### DIFF
--- a/tincr/io/device/xdlrc.tcl
+++ b/tincr/io/device/xdlrc.tcl
@@ -291,7 +291,7 @@ proc ::tincr::write_xdlrc_tile { tile outfile brief } {
         }
         
 #        puts "Printing PIP information..."
-        set pips [lsort [get_pips -quiet -of_object $tile -filter !IS_TEST_PIP]]
+        set pips [lsort [get_pips -quiet -of_objects $tile -filter {!IS_TEST_PIP && !IS_EXCLUDED_PIP}]]
         foreach pip $pips {
             set uphill_node [get_nodes -quiet -uphill -of_object $pip]
             set downhill_node [get_nodes -quiet -downhill -of_object $pip]


### PR DESCRIPTION
PIPs that are marked as "excluded" should not be included in the XDLRC files generated by write_xdlrc.
