### PR TITLE
Fixed spacing error in write_routing_rs2

### DIFF
--- a/tincr/io/design/tincr_checkpoints.tcl
+++ b/tincr/io/design/tincr_checkpoints.tcl
@@ -521,7 +521,7 @@ proc ::tincr::write_routing_rs2 {args} {
 				# assuming that the second tile in the tile list is the interconnect tile
 				set switchbox_tile [lindex $tiles 1]
 				set route_string [string range [get_property ROUTE $net] 3 end-3]
-				set route_string "( \{$switchbox_tile/$route_string\} )"
+				set route_string "( \{ $switchbox_tile/$route_string \} )"
 			}
 		}
 		


### PR DESCRIPTION
Just a minor tweak - there was insufficient space between the { and the rest of the routing string which messed up the RS2 parser.
