### PR TITLE
genCellLibrary and genFamilyInfo added to Tincr namespace

### DIFF
--- a/tincr/io/library/genCellLibrary.tcl
+++ b/tincr/io/library/genCellLibrary.tcl
@@ -6,7 +6,7 @@ package require tincr.cad.util 0.0
 
 namespace eval ::tincr:: {
     namespace export \
-        createCellLibrary
+        create_xml_cell_library
 }
 
 # This script creates the cellLibrary.xml file needed for RapidSmith2.
@@ -316,18 +316,15 @@ proc printPortHeader {fo type pin_direction} {
 
 proc writePortXML { fo lc dict } {
 
-    puts "Doing ports..."
+    puts "Creating port definitions..."
 
 
     printPortHeader $fo "IPORT" "output"
     
     dict for {type site} $dict {
-	if {![get_property IS_PAD $site]} {
-	    continue;
-	}
-        foreach b [get_bels -of $site] {
-            if { [get_property TYPE $b] == "PAD" } {
-                if { [get_property NUM_OUTPUTS $site] > 0 } {
+	if {[get_property IS_PAD $site] && [get_property NUM_OUTPUTS $site] > 0 } {
+	    foreach b [get_bels -of $site] {
+		if { [get_property TYPE $b] == "PAD" } {
                     puts $fo "        <bel>"
                     puts $fo "          <id>"
                     puts $fo "            <primitive_type>$type</primitive_type>"
@@ -345,12 +342,9 @@ proc writePortXML { fo lc dict } {
     printPortHeader $fo "OPORT" "input"
     
     dict for {type site} $dict {
-	if {![get_property IS_PAD $site]} {
-	    continue;
-	}
+	if {[get_property IS_PAD $site] && [get_property NUM_INPUTS $site] > 0 } {
         foreach b [get_bels -of $site] {
             if { [get_property TYPE $b] == "PAD" } {
-                if { [get_property NUM_INPUTS $site] > 0 } {
                     puts $fo "        <bel>"
                     puts $fo "          <id>"
                     puts $fo "            <primitive_type>$type</primitive_type>"
@@ -368,12 +362,9 @@ proc writePortXML { fo lc dict } {
     printPortHeader $fo "IOPORT" "inout"
     
     dict for {type site} $dict {
-	if {![get_property IS_PAD $site]} {
-	    continue;
-	}
-        foreach b [get_bels -of $site] {
-            if { [get_property TYPE $b] == "PAD" } {
-                if { [get_property NUM_INPUTS $site] > 0 && [get_property NUM_OUTPUTS $site] > 0 } {
+	if {[get_property IS_PAD $site] && [get_property NUM_INPUTS $site] > 0  && [get_property NUM_OUTPUTS $site] > 0 } {
+	    foreach b [get_bels -of $site] {
+		if { [get_property TYPE $b] == "PAD" } {
                     puts $fo "        <bel>"
                     puts $fo "          <id>"
                     puts $fo "            <primitive_type>$type</primitive_type>"
@@ -390,7 +381,7 @@ proc writePortXML { fo lc dict } {
 }
 
 #top level function used to create a cell library file used in RapidSmith2
-proc ::tincr::createCellLibrary { {part xc7a100t-csg324-3} {filename ""} } {
+proc ::tincr::create_xml_cell_library { {part xc7a100t-csg324-3} {filename ""} } {
 
     set part_list [split $part "-"]
 
@@ -446,10 +437,10 @@ proc ::tincr::createCellLibrary { {part xc7a100t-csg324-3} {filename ""} } {
         
         # Mark VCC and GND cells
         if { $cname == "VCC" } {
-            puts $fo "          <vcc_source></vcc_source>"
+            puts $fo "        <vcc_source/>"
         }
         if { $cname == "GND" } {
-            puts $fo "          <gnd_source></gnd_source>"
+            puts $fo "        <gnd_source/>"
         }
 
         

--- a/tincr/io/library/genCellLibrary.tcl
+++ b/tincr/io/library/genCellLibrary.tcl
@@ -1,4 +1,13 @@
-package require tincr 0.0
+package provide tincr.io.library 0.0
+package require Tcl 8.5
+package require tincr.cad.design 0.0
+package require tincr.cad.device 0.0
+package require tincr.cad.util 0.0
+
+namespace eval ::tincr:: {
+    namespace export \
+        createCellLibrary
+}
 
 # This script creates the cellLibrary.xml file needed for RapidSmith2.
 # All function used are encapsulated into this file
@@ -319,7 +328,7 @@ proc doPorts { fo } {
                     puts $fo "        <bel>"
                     puts $fo "          <id>"
                     puts $fo "            <primitive_type>$type</primitive_type>"
-                    puts $fo "            <name>PAD</name>"
+                    puts $fo "            <name>[suffix [get_property NAME $b] "/"]</name>"
                     puts $fo "          </id>"
                     puts $fo "        </bel>"
                 }
@@ -351,7 +360,7 @@ proc doPorts { fo } {
                     puts $fo "        <bel>"
                     puts $fo "          <id>"
                     puts $fo "            <primitive_type>$type</primitive_type>"
-                    puts $fo "            <name>PAD</name>"
+                    puts $fo "            <name>[suffix [get_property NAME $b] "/"]</name>"
                     puts $fo "          </id>"
                     puts $fo "        </bel>"
                 }
@@ -383,7 +392,7 @@ proc doPorts { fo } {
                     puts $fo "        <bel>"
                     puts $fo "          <id>"
                     puts $fo "            <primitive_type>$type</primitive_type>"
-                    puts $fo "            <name>PAD</name>"
+                    puts $fo "            <name>[suffix [get_property NAME $b] "/"]</name>"
                     puts $fo "          </id>"
                     puts $fo "        </bel>"
                 }
@@ -396,7 +405,7 @@ proc doPorts { fo } {
 }
 
 #top level function used to create a cell library file used in RapidSmith2
-proc createCellLibrary { {part xc7a100t-csg324-3} {filename ""} } {
+proc ::tincr::createCellLibrary { {part xc7a100t-csg324-3} {filename ""} } {
 
     set part_list [split $part "-"]
 
@@ -524,7 +533,7 @@ proc createCellLibrary { {part xc7a100t-csg324-3} {filename ""} } {
 #set sites [uniqueSites
 
 #function call to generate the cell library file
-createCellLibrary xc7a100t-csg324-3
+#createCellLibrary xc7a100t-csg324-3
 
 # Notes
 # ------

--- a/tincr/io/library/genFamilyInfo.tcl
+++ b/tincr/io/library/genFamilyInfo.tcl
@@ -1,3 +1,13 @@
+package provide tincr.io.library 0.0
+package require Tcl 8.5
+package require tincr.cad.design 0.0
+package require tincr.cad.device 0.0
+package require tincr.cad.util 0.0
+
+namespace eval ::tincr:: {
+    namespace export \
+	createFamilyInfo
+}
 # Source-ing this file will create the basic familyInfo file called
 # 'familyInfo_new.xml'.
 
@@ -222,7 +232,7 @@ proc printSingleBelPrimitiveList {sites fo} {
 
  
 #main function
-proc createFamilyInfo { } {
+proc ::tincr::createFamilyInfo { } {
 	# open output file 
 	createBlankDesignByPart xc7a100t-csg324-1 
 
@@ -316,5 +326,5 @@ proc createFamilyInfo { } {
 	close_design	
 } 
 
-createFamilyInfo
+#createFamilyInfo
 

--- a/tincr/io/library/genFamilyInfo.tcl
+++ b/tincr/io/library/genFamilyInfo.tcl
@@ -6,7 +6,7 @@ package require tincr.cad.util 0.0
 
 namespace eval ::tincr:: {
     namespace export \
-	createFamilyInfo
+	create_xml_familyinfo
 }
 # Source-ing this file will create the basic familyInfo file called
 # 'familyInfo_new.xml'.
@@ -251,11 +251,11 @@ proc printSingleBelPrimitiveList {sites fo} {
 
  
 #main function
-proc ::tincr::createFamilyInfo { {part xc7a100t-csg324} } {
+proc ::tincr::create_xml_familyinfo { {part xc7a100t-csg324} } {
 	# open output file 
 	createBlankDesignByPart $part 
 
-	set fo [open "familyInfo_$part.xml" w]
+	set fo [open "familyInfo_${part}.xml" w]
 
 	# print XML header 
 	puts $fo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"

--- a/tincr/io/library/genFamilyInfo.tcl
+++ b/tincr/io/library/genFamilyInfo.tcl
@@ -179,6 +179,19 @@ proc processSite {s type compatible is_alt fo} {
 		puts $fo "        <bel>"
 		puts $fo "          <name>$tmpname</name>"
 		puts $fo "          <type>$tmpname</type>"
+
+		#print routethroughs if it is a LUT
+		if { [string first "LUT" $tmpname] == 2 } {
+		    puts $fo "          <routethroughs>"
+		    set siz [string range $tmpname 1 1]
+		    for { set i 1}  {$i <= $siz} {incr i} {
+			puts $fo "            <routethrough>"
+			puts $fo "              <input>A$i</input>"
+			puts $fo "              <output>O$siz</output>"
+			puts $fo "            </routethrough>"
+		    }
+		    puts $fo "          </routethroughs>"
+		}
 		puts $fo "        </bel>"
 	}
     puts $fo "      </bels>"

--- a/tincr/io/library/genFamilyInfo.tcl
+++ b/tincr/io/library/genFamilyInfo.tcl
@@ -245,11 +245,11 @@ proc printSingleBelPrimitiveList {sites fo} {
 
  
 #main function
-proc ::tincr::createFamilyInfo { } {
+proc ::tincr::createFamilyInfo { {part xc7a100t-csg324} } {
 	# open output file 
-	createBlankDesignByPart xc7a100t-csg324-1 
+	createBlankDesignByPart $part 
 
-	set fo [open "familyInfo_thomas.xml" w]
+	set fo [open "familyInfo_$part.xml" w]
 
 	# print XML header 
 	puts $fo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"

--- a/tincr/io/library/genFamilyInfo.tcl
+++ b/tincr/io/library/genFamilyInfo.tcl
@@ -181,9 +181,15 @@ proc processSite {s type compatible is_alt fo} {
 		puts $fo "          <type>$tmpname</type>"
 
 		#print routethroughs if it is a LUT
-		if { [string first "LUT" $tmpname] == 2 } {
+		set siz -1
+		if { [get_property TYPE $b] == "LUT5" } {
+		    set siz 5
+		}
+		if { [get_property TYPE $b] == "LUT6" } {
+		    set siz 6
+		}
+		if { $siz != -1 } {
 		    puts $fo "          <routethroughs>"
-		    set siz [string range $tmpname 1 1]
 		    for { set i 1}  {$i <= $siz} {incr i} {
 			puts $fo "            <routethrough>"
 			puts $fo "              <input>A$i</input>"

--- a/tincr/io/library/pkgIndex.tcl
+++ b/tincr/io/library/pkgIndex.tcl
@@ -1,0 +1,6 @@
+if {[info exists ::env(TINCR_PATH)]} {
+    package ifneeded tincr.io.library 0.0 {
+        source [file join $::env(TINCR_PATH) tincr io library genCellLibrary.tcl]
+        source [file join $::env(TINCR_PATH) tincr io library genFamilyInfo.tcl]
+    }
+}

--- a/tincr/io/pkgIndex.tcl
+++ b/tincr/io/pkgIndex.tcl
@@ -1,6 +1,7 @@
 if {[info exists ::env(TINCR_PATH)]} {
     source [file join $::env(TINCR_PATH) tincr io design pkgIndex.tcl]
     source [file join $::env(TINCR_PATH) tincr io device pkgIndex.tcl]
+    source [file join $::env(TINCR_PATH) tincr io library pkgIndex.tcl]
     
     package ifneeded tincr.io 0.0 {
         source [file join $::env(TINCR_PATH) tincr io tincr.io.tcl]


### PR DESCRIPTION
Added support in genCellLibrary for LUTs, VCC/GND, and ports.
Also, added routethroughs.
