### PR TITLE
write_xdlrc only writes used primitive definitions

### DIFF
--- a/tincr/io/device/xdlrc.tcl
+++ b/tincr/io/device/xdlrc.tcl
@@ -142,7 +142,7 @@ proc ::tincr::write_xdlrc { args } {
         # Newline
         puts "\rPercent complete: 100%"
         
-        set site_types [::tincr::sites get_types]
+        set site_types [::tincr::sites get_types [get_sites]]
     
         if {$primitive_defs} {
             # Primitive Definitions


### PR DESCRIPTION
We want write_xdlrc to only write out the primitive definitions of the site types that are actually used in a device, instead of all possible site types.
