### PR TITLE
Load tincr.io.library with "package require tincr"

### DIFF
--- a/tincr/io/tincr.io.tcl
+++ b/tincr/io/tincr.io.tcl
@@ -2,3 +2,4 @@ package provide tincr.io 0.0
 
 package require tincr.io.design 0.0
 package require tincr.io.device 0.0
+package require tincr.io.library 0.0


### PR DESCRIPTION
When a user types `package require tincr`, Tincr loads all of its packages hierarchically. First, the TCL interpreter executes the contents of [tincr/tincr.tcl](https://github.com/byuccl/tincr/blob/master/tincr/tincr.tcl). This file loads both the `tincr.cad` and `tincr.io` packages, which are defined in [tincr/cad/tincr.cad.tcl](https://github.com/byuccl/tincr/blob/master/tincr/cad/tincr.cad.tcl) and [tincr/io/tincr.io.tcl](https://github.com/byuccl/tincr/blob/master/tincr/io/tincr.io.tcl). Each of these files load the set of packages that live under them. For example, `package require tincr.io` loads `tincr.io.design` and `tincr.io.device`.
This change adds `package require tincr.io.library` to [tincr/io/tincr.io.tcl](https://github.com/byuccl/tincr/blob/master/tincr/io/tincr.io.tcl).
