### PR TITLE
Updated TCP to include routethrough output pin and fixed ROUTE string bug

### DIFF
--- a/tincr/cad/device/bels.tcl
+++ b/tincr/cad/device/bels.tcl
@@ -258,7 +258,14 @@ proc ::tincr::bels::is_lut {args} {
 # @param bel The <CODE>bel</CODE> object.
 # @return True (1) if this BEL is being used as a route through, false (0) otherwise.
 proc ::tincr::bels::is_route_through {bel} {
-    # TODO This is a planned feature
+    
+    # If a BEL is used, it can't be a routethrough
+    if { [get_property IS_USED $bel] } {
+        return false;
+    }
+    
+    # If its not used, test the CONFIG.EQN string of the bel
+    return [regexp {O[5,6]=\(A[1-6]\) ?} [get_property CONFIG.EQN $bel] match]
 }
 
 ## Remove the route-through (i.e. replace it with a BUF cell)


### PR DESCRIPTION
## In this commit:
- Updated the format of the routing.rcp file to include the output pin for a LUT routethrough. This is important because LUT6 bels on SLICEM sites have two output pins, but only one is associated with the LUT (the O6 pin). This change removes an ambiguity for parsing in RapidSmith. 
- Fixed a bug that would print the ROUTE string of a net even if it was empty. Now, an empty ROUTE string will not print to the routing.rcp file. 
- Implemented the `tincr::bels::is_routethrough` method to detect LUT routethroughs in the design.
