### PR TITLE
Updates to cell library generation

### DIFF
--- a/tincr/cad/design/pins.tcl
+++ b/tincr/cad/design/pins.tcl
@@ -23,7 +23,8 @@ namespace eval ::tincr::pins {
         info \
         remove \
         connect_net \
-        disconnect_net
+        disconnect_net \
+        get_pin_type
     namespace ensemble create
 }
 
@@ -114,4 +115,35 @@ proc ::tincr::pins::connect_net { pin net } {
 # @param net The <CODE>net</CODE> object.
 proc ::tincr::pins::disconnect_net { pin net } {
     disconnect_net -quiet -net $net $pin
+}
+
+## Gets the type of the pin according to Vivado. DATA is the
+#   default pin type where no other pin type is specified. Other valid pin types
+#   include CLEAR, CLOCK, ENABLE, PRESET, RESET, SET, SETRESET, AND WRITE_ENABLE
+#   TODO: on each new release of Vivado, verify this function is still correct.
+#           This has to be manually verified.
+#
+# @param pin Cell pin
+# @return The type of cell pin
+proc ::tincr::pins::get_pin_type { pin } {
+
+    if { [get_property IS_CLEAR $pin] } {
+        return "CLEAR"
+    } elseif { [get_property IS_CLOCK $pin] } {
+        return "CLOCK"
+    } elseif { [get_property IS_ENABLE $pin] } {
+        return "ENABLE"
+    } elseif { [get_property IS_PRESET $pin] } {
+        return "PRESET"
+    } elseif { [get_property IS_RESET $pin] } {
+        return "RESET"
+    } elseif { [get_property IS_SET $pin] } {
+        return "SET"
+    } elseif { [get_property IS_SETRESET $pin] } {
+        return "SETRESET"
+    } elseif { [get_property IS_WRITE_ENABLE $pin] } {
+        return "WRITE_ENABLE"
+    } else {
+        return "DATA"
+    }
 }

--- a/tincr/cad/util/util.tcl
+++ b/tincr/cad/util/util.tcl
@@ -55,6 +55,7 @@ namespace eval ::tincr {
         organize_by \
         print_verbose \
         assert \
+        suffix 
 }
 
 # ================== Files and Other I/O ================== #
@@ -1253,6 +1254,16 @@ proc ::tincr::add_extension { args } {
     }
     
     return $filename
+}
+
+## Splits the <code>string</code> by <code>token</code>, and returns the last element in the list.
+#  Helper function used to get the relative name of Vivado elements. For example, the call
+#  <code>suffix "I/am/a/test" "/"</code> will return the string "test."
+#
+# @param string The string to split 
+# @param token The token to split the string on
+proc ::tincr::suffix { string token } {
+    return [lindex [split $string $token] end]
 }
 
 ## Format a string so that it is valid XML.

--- a/tincr/io/library/genCellLibrary.tcl
+++ b/tincr/io/library/genCellLibrary.tcl
@@ -6,43 +6,54 @@ package require tincr.cad.util 0.0
 
 namespace eval ::tincr:: {
     namespace export \
-        create_xml_cell_library
+        create_xml_cell_library \
+        test_cell_library
 }
 
 # This script creates the cellLibrary.xml file needed for RapidSmith2.
 # All function used are encapsulated into this file
-# TODO: Incorporate this into the TINCR distribution
 
-#open a new design in Vivado with the specified part
-proc create_blank_design_by_part { part } {
-    return [tincr::designs new mydes $part]
+## Get the name of a BEL.
+# @param bel The <CODE>bel</CODE> object.
+# @return The name of the BEL as a string.
+
+## Splits the <code>string</code> by <code>token</code>, and returns the last element in the list.
+#  Helper function used to get the relative name of Vivado elements. For example, the call
+#  <code>suffix "I/am/a/test" "/"</code> will return the string "test."
+#  TODO: add to tincr.util
+#
+# @param string The string to split 
+# @param token The token to split the string on
+proc suffix { string token } {
+    return [lindex [split $string $token] end]
 }
 
-# helper function used to get the relative name of Vivado elements
-# TODO: add to tincr.util
-proc suffix { s p } {
-    return [lindex [split $s $p] end]
-}
-
-# test if a cell can be placed on a particular BEL
+## Tests if a cell can be placed on a particular BEL. 
+#
 # TODO: Add to tincr::cell
-proc is_my_placement_legal { c b } {
-    unplace_cell $c
-
-    if {[catch {place_cell $c $b} fid] == 0} {
-        if { [suffix $b "/"] == [suffix [get_property BEL $c] "."] } then {
-            unplace_cell $c
-            return 1
-        } else {
-            unplace_cell $c
-            return 0
+# @param cell The <code>cell<code> instance to be placed
+# @param bel The <code>bel</code> to try placing <code>cell<code> on.
+proc is_my_placement_legal { cell bel } {
+    unplace_cell $cell
+   
+    set success 0 
+    if {[catch {place_cell $cell $bel} fid] == 0} {
+        if { [suffix $bel "/"] == [suffix [get_property BEL $cell] "."] } then {            
+            set success 1
         }
     }
-    return 0
+    
+    unplace_cell $cell
+    
+    return $success
 }
 
-# create a list of all supported cells in the current design
-# TODO: find a way to merge the top and bottom funtion
+## Creates a list of all supported leaf cells in the current device. Leaf cells are marked
+#   as supported if, when instantiated, the reference name of the cell instance matches the name
+#   of the library cell. Macro cells are excluded 
+#   TODO: find a way to merge this and get_supported_lib_cells 
+#
+# @return A list of supported leaf cells.
 proc get_supported_leaf_libcells { } {
     set lib_cells [get_lib_cells]
     set supported_cells [list]
@@ -62,8 +73,12 @@ proc get_supported_leaf_libcells { } {
     return $supported_cells
 }
 
-#create a list of all supported cells in the current design
-# TODO: update this
+## Creates a list of all supported cells in the current device. Cells are marked
+#   as supported if, when instantiated, the reference name of the cell instance matches the name
+#   of the library cell. Macro cells are included. 
+#   TODO: update this 
+#
+# @return A list of supported cells.
 proc get_supported_libcells { } {
     set lib_cells [get_lib_cells]
     set supported_cells [list]
@@ -74,176 +89,583 @@ proc get_supported_libcells { } {
         if {[get_property REF_NAME $c] == $lbc} {
             lappend supported_cells $lbc
         }
-        remove_cell [get_cells tmp]
+        remove_cell $c
     }
 
     return $supported_cells
 }
 
-# modified version of the tincr::sites::unique function to get a handle to each primitive site type
-# it chooses default site locations over alternate site locations
-proc unique_sites {} {
-    set sites [dict create]
+## Modified version of the <code>tincr::sites::unique</code> function to get a handle
+#   to each primitive site type in the current device. This function chooses 
+#   default site locations over alternate site locations, and chooses a different
+#   site location for alternate types if possible. 
+#   TODO: update the tincr::sites::unique function
+#
+# @returns A list with two elements. <br>
+#           (1) The first element is the map from a site type to a site location <br>
+#           (2) A set of site types that are only alternate site types <br>
+proc create_unique_site_maps { } {
+    set default_sites [dict create]
     set alternates [dict create]
-
+    set global_site_map [dict create]
+        
     foreach site [get_sites] {
-        #create a dictionary of default site types
-        if {![dict exists $sites [get_property SITE_TYPE $site]]} {
-            dict set sites [get_property SITE_TYPE $site] $site
+        
+        set default_site_type [get_property SITE_TYPE $site]
+        
+        dict lappend global_site_map $default_site_type $site
+        
+        # add to the map of default site types if we haven't encountered this site type before
+        if {![dict exists $default_sites $default_site_type]} {
+            dict set default_sites $default_site_type $site
         }
 
-        #create a dictionary of alternate site types
-        foreach type [get_property ALTERNATE_SITE_TYPES $site] {
-            if {![dict exists $alternates $type]} {
-                dict set alternates $type $site
+        # add all alternate site types to the alternate site map
+        foreach alternate_type [get_property ALTERNATE_SITE_TYPES $site] {
+            if {![dict exists $alternates $alternate_type]} {
+                dict set alternates $alternate_type $default_site_type
             }
         }
     }
-
-    # If a site in the alternate dictionary is not already in the default dictionary, add it
+    
+    set alternate_only_site_set [list]
+    # If a site in the alternate dictionary is not already in the default dictionary, add it with a unique site
     # NOTE: IOB sites cause Vivado to crash when you set alternate site types that are IOBs
-    #   so, unfortunately, we have to ignore these until the bug is fixed.
-    dict for {type site} $alternates {
-        if {![dict exists $sites $type] &&  ![regexp {.*IOB*} $type]} {
-            dict set sites $type $site
+    #   so, unfortunately, we have to ignore these until the bug is fixed. This is generally not an 
+    #   issue because all IOB sites show up as non-default types. 
+    dict for {alternate_type site} $alternates {
+        if { ![dict exists $default_sites $alternate_type] && ![string match {*IOB*} $alternate_type] } {
+            
+            set site_list [dict get $global_site_map $site]
+            ::tincr::assert { [llength $site_list] > 0 } "Bad assumption. Alternate site only can be placed in one location. Re-evaluate script. $alternate_type -> $site_list"
+            
+            # grab a unique site for the alternate site so we don't mess up the placement on default site types
+            dict set default_sites $alternate_type [lindex $site_list 1]
+            ::struct::set add alternate_only_site_set $alternate_type
         }
     }
-
-    return $sites
+    
+    return [list $default_sites $alternate_only_site_set]
 }
 
+## Creates a dictionary that maps a cell object, to all site locations where it
+#   can be validly placed.
 #
-#Input parameters: list of library cells and a dictionary of sites
-proc create_cell_to_site_map {lib_cells site_map} {
-    set should_reset 0
+# @param lib_cells List of supported library cells for the current device
+# @param site_map Dictionary mapping site types, to site locations
+# @param alternate_site_set Set of sites that are only alternate sites
+# @return A dictionary that maps a cell to all sites it can be placed on
+proc create_cell_to_site_map {lib_cells site_map alternate_site_set} {
+    
     set cell_site_map [dict create]
-
-    foreach lbc $lib_cells {
-        set c [create_cell -reference $lbc tmp -quiet]
-
-        # try to place each lib_cell on each site
+    
+    foreach lib_cell $lib_cells {
+        
+        set cell_instance [create_cell -reference $lib_cell tmp -quiet]
+        
+        # try to place each lib_cell on each default site
         dict for {sitename site} $site_map {
-
-            if { [regexp {.*IOB*} $sitename] == 0 } {
-                set_property MANUAL_ROUTING $sitename $site
-                set should_reset 1
+            
+            # set the manual routing property for a site ONLY IF the site type is an alternate only 
+            set is_alternate 0
+            if { [::struct::set contains $alternate_site_set $sitename] } {
+                set is_alternate 1
+                set_property MANUAL_ROUTING $sitename $site 
             }
-
-            if {[catch {[place_cell $c $site]} err] == 0} {
-                dict lappend cell_site_map $lbc $sitename
-                unplace_cell $c
+            
+            if {[catch {[place_cell $cell_instance $site]} err] == 0} {
+                dict lappend cell_site_map $lib_cell $sitename
+                unplace_cell $cell_instance
             }
-
-            if { $should_reset } {
+            
+            if { $is_alternate } {
                 reset_property MANUAL_ROUTING $site
-                set should_reset 0
             }
         }
-        remove_cell [get_cells *]
+        
+        # Print all unsupported lib cells for the part (this is for debugging)
+        if { $::tincr::debug && ![dict exists $cell_site_map $lib_cell] } {
+            puts "\[Warning\] Library Cell: $lib_cell not supported for the current part. Please Review"
+        }
+        
+        remove_cell $cell_instance -quiet
     }
-
-    #VCC and GND cells are not placeable, but we still want to include them in our xml file
-    dict set cell_site_map "VCC" [list]
-    dict set cell_site_map "GND" [list]
+    
+    #VCC and GND cells are not place-able, but we still want to include them in our XML file
+    dict set cell_site_map [get_lib_cells VCC] [list]
+    dict set cell_site_map [get_lib_cells GND] [list]
+        
     return $cell_site_map
 }
 
+## Creates the cell library XML for a leaf cell
 #
-proc process_leaf_cell {c s fo} {
-    create_net tmp_net
-    foreach b [get_bels -of $s] {
-        if { [is_my_placement_legal $c $b] == 1 } then {
-            puts $fo "        <bel>"
-            puts $fo "          <id>"
-            puts $fo "            <primitive_type>[tincr::sites::get_type $s]</primitive_type>"
-            puts $fo "            <name>[suffix $b "/"]</name>"
-            puts $fo "          </id>"
+# @param cell Instance of a library cell to process
+# @param site Site location to place the cell on
+# @param xml_out Output file to print the XML to
+#
+proc process_leaf_cell {cell site xml_out} {
+  
+    # create_net tmp_net
+    set cell_group [get_property PRIMITIVE_GROUP $cell]
+    set cell_can_permute_pins [expr {$cell_group == "LUT" || $cell_group == "INV" || $cell_group == "BUF"}] 
+    
+    # Find all of the configurations of the cell : TODO: add this at a later date
+    if {$::tincr::debug} {
+        set config_list [list]
+        set config_value_map [dict create]
+        set value_count [get_configurations $cell config_list config_value_map]
+    
+        set has_configs [expr {[llength $config_list] > 0}]
+        global config_threshold
+        set above_threshold [expr {$value_count > $config_threshold}]
+    
+        puts "Config count: [llength $config_list] Value count: $value_count"
+    }
+    
+    foreach bel [get_bels -of $site] {
+        if { [is_my_placement_legal $cell $bel] == 1 } then {
+            puts $xml_out "        <bel>"
+            puts $xml_out "          <id>"
+            puts $xml_out "            <primitive_type>[tincr::sites::get_type $site]</primitive_type>"
+            puts $xml_out "            <name>[suffix $bel "/"]</name>"
+            puts $xml_out "          </id>"
 
             #if the placement is legal, place the cell onto the bel to get pin mapping info
-            place_cell $c $b
+            # place_cell $cell $bel
+            # set unconnectedCellPins [list]
 
-            #cell to bel pin name dictionary
-            set pin_mappings [dict create]
-            set unconnectedCellPins [list]
-
-            #Populate the cell pin to bel pin mappings dictionary
-            foreach cell_pin [get_pins -of $c] {
-                set ref_name_cp [lindex [split $cell_pin "/"] end]
-
-                #get the BEL pin to cell pin mapping
-                set bel_pin [get_bel_pins -of $cell_pin -quiet]
-
-                if {$bel_pin != "" } {
-                    set ref_name_bp [lindex [split [get_property NAME $bel_pin] "/"] end]
-
-                    #if the bel pin name does not match the cell pin name, then add it as a possible name
-                    if { $ref_name_bp != $ref_name_cp } {
-                        dict lappend pin_mappings $ref_name_cp $ref_name_bp
-                    }
-                } else {
-                    set group [get_property PRIMITIVE_GROUP $c]
-                    if {$group != "LUT" && $group != "INV" && $group != "BUF"} {
-                        lappend unconnectedCellPins $cell_pin
-                    } else {
-                        #For LUT/INV/BUF primitives, a cell pin can map to multiple bel pins
-                        #this code determines the valid mappings for each cell pin in these cases
-                        foreach bp [get_bel_pins -of $b -filter {DIRECTION==IN} -quiet] {
-                            set ref_name_bp [lindex [split [get_property NAME $bp] "/"] end]
-
-                            if { [catch {[set_property LOCK_PINS "{$ref_name_cp:$ref_name_bp}" $c]} t] == 0 } {
-                                dict lappend pin_mappings $ref_name_cp $ref_name_bp
-                            }
-                            reset_property LOCK_PINS $c
-                        }
-                    }
+            # create a dictionary of cell pin to BEL pin mappings
+            if {$cell_can_permute_pins} {
+                # set pin_map [create_leaf_cell_pin_mapping_permutable $cell $bel]
+                create_leaf_cell_pin_mapping_permutable $cell $bel $xml_out
+            } else {
+                get_static_leaf_cell_pin_mappings $cell $bel $xml_out
+            }
+            
+            if {0} { ; # START COMMENT
+            else {
+                                
+                # If the cell has no configs or the # of configs are above the maximum threshold, 
+                # call the static cell pin function
+                if { !$has_configs || $above_threshold } {
+                    get_static_leaf_cell_pin_mappings $cell $bel $xml_out
+                } else { ; # otherwise, call the dynamic function
+                    # TODO: create a dictionary here?
+                    get_dynamic_leaf_cell_pin_mappings $cell $bel $config_list $config_value_map $xml_out
                 }
             }
-
-            # connect a net to each unconnected cell pin to see if this results in the cell pin being mapped to a bel pin
-            # this was added for a special case of the CARRY4 BEL. When it is placed, two of its cell pins are not
-            # mapped to bel pins (CI and CYINIT). However, when you connect a net to these pins, the mapping is created.
-            # Since a carry4 cell is not a LUT,INV, or BUF, we cannot use the LOCK_PINS property to try and map the cell
-            # pins onto bel pins
-
-            foreach cell_pin $unconnectedCellPins {
-                connect_net -net [get_nets tmp_net] -objects [get_pins $cell_pin]
-
-                set bel_pin [get_bel_pins -of $cell_pin -quiet]
-
-                if {$bel_pin != "" } {
-                    set ref_name_bp [lindex [split [get_property NAME $bel_pin] "/"] end]
-                    set ref_name_cp [lindex [split $cell_pin "/"] end]
-
-                    if { $ref_name_bp != $ref_name_cp } {
-                        dict lappend pin_mappings $ref_name_cp $ref_name_bp
-                    }
-                }
-                disconnect_net -net [get_nets tmp_net] -objects [get_pins $cell_pin]
-            }
-
-            #print the pin mappings to the file
-            if { [expr {[dict size $pin_mappings] > 0}] } {
-                puts $fo "          <pins>"
-
-                dict for {cp bp} $pin_mappings {
-                    puts $fo "            <pin>"
-                    puts $fo "              <name>$cp</name>"
-                    foreach b_p $bp {
-                        puts $fo "              <possible>$b_p</possible>"
-                    }
-                    puts $fo "            </pin>"
-                }
-                puts $fo "          </pins>"
-            }
-
-            puts $fo "        </bel>"
+            } ; # END COMMENT
+            
+            puts $xml_out "        </bel>"
         }
     }
-    unplace_cell $c
-    remove_net [get_nets tmp_net]
+    unplace_cell $cell
+    # remove_net [get_nets tmp_net]
 }
 
+## Gets the cell pin to bel pin mappings for a cell that DOES NOT have 
+#   configurable pin mappings (i.e. don't change based on how it is configured).
+#   Writes these pin mappings to the specified XML file.
 #
+# @param cell Cell instance
+# @param bel Bel to place the cell on
+# @param xml_out File handle to write the pin mapping XML
+proc get_static_leaf_cell_pin_mappings { cell bel xml_out } {
+    
+    place_cell $cell $bel
+    attach_nets $cell
+    
+    set pin_map [dict create]
+    set unconnected_pins [list]
+    foreach cell_pin [get_pins -of $cell] {
+        
+        set mapped_bel_pins [get_bel_pins -of $cell_pin -quiet]
+        
+        if {[llength $mapped_bel_pins] == 0 } {
+            lappend unconnected_pins $cell_pin
+        } else {
+        
+            if { $::tincr::debug &&  [llength $mapped_bel_pins] > 1 } {
+                puts "# Multiple Mappings: [get_lib_cells -of $cell -quiet] $cell_pin"
+            }
+            dict set pin_map $cell_pin [list]
+            foreach bel_pin $mapped_bel_pins {
+                dict lappend pin_map $cell_pin $bel_pin
+            }
+        }
+    }
+    
+    remove_net * -quiet
+    
+    foreach cell_pin $unconnected_pins {
+        set net [create_net tmp]
+        connect_net -net $net -objects $cell_pin
+        set mapped_bel_pins [get_bel_pins -of $cell_pin -quiet]
+
+        dict set pin_map $cell_pin [list]
+        foreach bel_pin $mapped_bel_pins {
+            dict lappend pin_map $cell_pin $bel_pin
+        }
+        
+        remove_net $net
+    }
+    
+    unplace_cell $cell
+    
+    write_possible_pin_mappings $pin_map $xml_out
+    # write_pin_mappings $cell [list $pin_map] [list "DEFAULT"] $xml_out
+}
+
+## Creates and attaches a unique net to each pin of the specified cell. This function
+#   is used to get more accurate pin mappings while placing cells onto Bels
+#
+# @param cell Library cell instance
+proc attach_nets {cell} {
+
+    set count 0
+    foreach pin [get_pins -of $cell] {
+        set net [create_net "tmp$count"]
+        connect_net -net $net -objects $pin -quiet
+        incr count
+    }
+}
+
+## Gets the cell pin to bel pin mappings for a cell whose mappings are dependent
+#   on the cell's current configuration. Writes these pin mappings to the specified XML file.
+#   TODO: Use this function once RapidSmith supports configurable pin mappings.
+#   TODO: Update this function to support any number of configuration combinations
+#
+# @param cell Library cell instance
+# @param bel Bel object to place the cell on
+# @param config_list List of configurations that could affect the pin mapping
+# @param config_value_map Dictionary containing the possible values for each configuratoin in config_list
+# @param xml_out File handle to write the pin mapping XML
+proc get_dynamic_leaf_cell_pin_mappings { cell bel config_list config_value_map xml_out } {
+    
+    set config_count [llength $config_list]
+   
+    reset_configuration $cell $config_list
+    # attach_nets $cell
+            
+    set pin_map_list [list]
+    set configuration_settings [list "DEFAULT"]
+
+    set default_mappings [get_unique_pin_mappings $cell $bel $pin_map_list]
+    
+    ::tincr::assert {[dict size $default_mappings] > 0} 
+    lappend pin_map_list $default_mappings
+    
+    # Change one configuration at a time, and see how it changes the pin mappings against the default
+    # If the default pin mappings are changed, 
+    dict for {config value_list} $config_value_map {
+        
+        foreach value $value_list {
+            
+            set_property $config $value $cell
+            set pin_map [get_unique_pin_mappings $cell $bel [list $default_mappings]]
+            if { [dict size $pin_map] > 0 } { ; # i.e. new mappings are found
+                lappend pin_map_list $pin_map
+                lappend configuration_settings "$config:$value"
+            }
+            set_property $config [get_default_value $cell $config] $cell
+        }
+    }
+    
+    # Now, change two configurations at a time, and compare them against all single instance changes
+    # To determine if multiple configurations can work together to change the pin mappings
+    for { set i 0 } { $i < $config_count } { incr i } {
+        set config [lindex $config_list end] ; # grab the last config element
+        set config_list [lreplace $config_list end end] ; # remove it from the list
+        
+        foreach value [dict get $config_value_map $config] {
+            set_property $config $value $cell
+            
+            foreach other_config $config_list {
+                foreach other_value [dict get $config_value_map $other_config] {
+                    set_property $other_config $other_value $cell
+                    set pin_map [get_unique_pin_mappings $cell $bel $pin_map_list]
+                    if { [dict size $pin_map] > 0 } { ; # i.e. new mappings are found
+                        # puts "Found new mapping!"
+                        lappend pin_map_list $pin_map
+                        lappend configuration_settings "$config:$value $other_config:$other_value"
+                    }
+                    set_property $other_config [get_default_value $cell $other_config] $cell
+                }
+            }
+            
+            set_property $config [get_default_value $cell $config] $cell
+        }
+        
+        linsert $config_list 0 $config ; # add the processes element to the start of the list
+    }
+    
+    # Print the conditional configurations to the file
+    write_pin_mappings $cell $pin_map_list $configuration_settings $xml_out
+    
+    # remove all of the temporarily created nets
+    # remove_net *
+}
+
+## Gets the default value of a configuration for a given cell
+#   TODO: add this to tincr::cell?
+#
+# @param cell Library cell instance
+# @param config Configuration to get the default value of
+# @return The default value of the specified config
+proc get_default_value {cell config} {
+    return [get_property "CONFIG.$config.DEFAULT" [get_lib_cells -of $cell]]
+}
+
+## Resets the cell to its default configuration. 
+#   TODO: add this to tincr::cell?
+#
+# @param cell Library cell instance 
+# @param config_list List of configurations to reset 
+proc reset_configuration {cell config_list} {
+    
+    foreach config $config_list {
+        set default [get_property "CONFIG.$config.DEFAULT" [get_lib_cells -of $cell]]
+        set_property $config $default $cell  
+    }
+}
+
+## Gets all configurations on the specified cell that could possible affect cell pin to 
+#   bel pin mappings. Only configurations with discrete values are returned.
+#   TODO: rename this to be more descriptive?
+#
+# @param cell Library cell instance
+# @param config_lst Reference list that will be populated to include
+#           all important configurations on the cell. In general, you should
+#           pass an empty list into this function.   
+# @param config_mp Reference dictionary that will be populated with a 
+#           a map from configuration to all possible values for that config.
+#           In general, an empty dictionary should be passed into this function
+proc get_configurations { cell config_lst config_mp } {
+    
+    upvar $config_lst config_list
+    upvar $config_mp config_map
+    set lib_cell [get_lib_cells -of $cell]
+    
+    set value_count 0
+    
+    foreach property [list_property $lib_cell] {
+    
+        # look for the CONFIG properties that have default values
+        if { [regexp {CONFIG\.([^\.]+)\.DEFAULT$} $property -> match] } {
+            
+            # filter out configurations for simulation or with non-discrete ranges
+            if { ![string match "*SIM*" $match] && ![string match "min*" [get_property "CONFIG.$match.VALUES" $lib_cell]] } {
+                
+                # split the values on whitespaces
+                set value_list [regexp -all -inline {\S+} [get_property "CONFIG.$match.VALUES" $lib_cell]]
+
+                set default_value [get_property $property $lib_cell]
+                if {[catch {set_property $match $default_value $cell} fid] == 1} {
+                    if {$::tincr::debug} {
+                        puts "\[Warning\] Property $match cannot be set on library cell $lib_cell in the TCL interface. This property might affect pin mappings."
+                    }
+                } elseif { [llength $value_list] > 0 } {              
+                    # add the values to the value map
+                    foreach value $value_list  {
+                        dict lappend config_map $match [string trim $value ","]
+                    }
+                    
+                    lappend config_list $match
+                    incr value_count [llength $value_list]
+                }
+            }
+        }
+    }
+
+    return $value_count
+}
+
+## Returns a dictionary of new pin mappings after the configurations of a cell
+#   have been changed. Only pin mappings that have changed are included. 
+#
+# @param cell Library cell instance
+# @param bel Bel object to place the cell on
+# @param pinmap_list A list of pin mappings for all configurations already tested
+# @return a dictionary of pin mappings that have been changed
+proc get_unique_pin_mappings { cell bel pinmap_list } {
+    
+    set new_mappings [dict create]
+    
+    # place the cell and then attach a net to all of the pins
+    place_cell $cell $bel
+    
+    set tmp_net [create_net tmp]
+    # attach_nets $cell
+    
+    foreach pin [get_pins -of $cell] {
+    
+        set mapped_bel_pins [get_bel_pins -of $pin -quiet] 
+        
+        if {[llength $mapped_bel_pins] == 0} {
+            #puts "Unconnected Net found!"
+            connect_net -net $tmp_net -objects $pin
+            set mapped_bel_pins [get_bel_pins -of $pin -quiet]
+            disconnect_net -objects $pin
+        }
+        
+        set exists 0
+        foreach dictionary $pinmap_list {
+            if { [dict exists $dictionary $pin] } {
+                set mapping [dict get $dictionary $pin]
+                if { $mapping == $mapped_bel_pins} {
+                    set exists 1
+                    break
+                }
+            }
+        }
+        
+        # we found a new pin mappings based on the current configuration
+        if {!$exists} {
+            dict set new_mappings $pin $mapped_bel_pins
+        }
+    }
+    
+    unplace_cell $cell
+    remove_net $tmp_net
+    # remove_net *
+    return $new_mappings
+}
+
+## Writes the cell pin to bel pin mappings to the specified output folder
+#   using the "possible" keyword. Currently, possible can either mean permutable
+#   pins, or multiple pin mappings.
+#   TODO: update this once configurable pin mappings are supported in RapidSmith
+#
+# @param pin_map Dictionary from cell pin -> list of bel pins
+# @param xml_out File handle to the output XML file
+proc write_possible_pin_mappings { pin_map xml_out } {
+
+    if { [dict size $pin_map] > 0 } {
+        puts $xml_out "          <pins>"
+    
+        dict for {cell_pin bel_pin_list} $pin_map {
+            puts $xml_out "            <pin>"
+            puts $xml_out "              <name>[get_property REF_PIN_NAME $cell_pin]</name>"
+            
+            if { [llength $bel_pin_list] == 0 } {
+                puts $xml_out "              <no_map/>"
+            } else {
+                foreach bel_pin $bel_pin_list {
+                    puts $xml_out "              <possible>[lindex [split $bel_pin "/"] end]</possible>"
+                }
+            }
+            puts $xml_out "            </pin>"
+        }
+        puts $xml_out "          </pins>"
+    }    
+}
+
+## Writes configurable pin mappings to the specified output file using the "conditional_map"
+#   convention. Currently, this function is not being used, but may be used in the future.
+#   TODO: revisit this once configurable pin mappings are supported in RapidSmith.
+#
+# @param cell Library cell instance
+# @param pin_map_list List of configurable pin mappings. The first pin mapping in the list
+#           should be the default pin mappings.
+# @param configuration_settings List of configurations for each corresponding pin_map
+# @param xml_out File handle to the output XML file
+proc write_pin_mappings { cell pin_map_list configuration_settings xml_out } {
+
+    foreach pin [get_pins -of $cell] {
+        
+        puts $xml_out "          <pin>"
+        puts $xml_out "            <name>[lindex [split $pin "/"] end]</name>"
+        
+        set count 0 
+        foreach pin_map $pin_map_list {
+        
+            set config [lindex $configuration_settings $count]
+            
+            if { ![dict exists $pin_map $pin] } {
+                incr count
+                continue;
+            }
+            set mapped_bel_pins [dict get $pin_map $pin]
+            
+            if {$count == 0} {
+                puts $xml_out "            <default_map>"
+            } else {
+                puts $xml_out "            <conditional_map>"
+            }
+            puts $xml_out "              <configuration>$config</configuration>"
+            
+            if { [llength $mapped_bel_pins] == 0} {
+                puts $xml_out "              <no_map/>"
+            } else {            
+                foreach bel_pin $mapped_bel_pins {
+                    puts $xml_out "              <map>[lindex [split $bel_pin "/"] end]</map>"
+                }
+            }
+            
+            if {$count == 0} {
+                puts $xml_out "            </default_map>"
+            } else {
+                puts $xml_out "            </conditional_map>"
+            }
+            incr count
+        }
+        puts $xml_out "          </pin>"
+    }
+}
+
+## Finds the cell pin to bel pin mappings for cells whose input pins are
+#   permutable (i.e LUT cells). Prints the discovered mappings to the
+#   specified output file.
+#
+# @param cell Library cell instance
+# @param cell Bel to place the cell onto
+# @param xml_out  File handle to the output XML file 
+proc create_leaf_cell_pin_mapping_permutable {cell bel xml_out} {
+    
+    place_cell $cell $bel
+    
+    set pin_map [dict create]
+    
+    set input_bel_pin_names [list] 
+    foreach input_bel_pin [get_bel_pins -of $bel -filter {DIRECTION==IN} -quiet] {
+        lappend input_bel_pin_names [lindex [split [get_property NAME $input_bel_pin] "/"] end]
+    }
+    
+    foreach cell_pin [get_pins -of $cell] {
+        
+        set is_input [expr {[get_property DIRECTION $cell_pin] == "IN"}]
+       
+        set cell_pin_name [lindex [split $cell_pin "/"] end]
+        set bel_pins [get_bel_pins -of $cell_pin -quiet]
+        
+        if {$is_input} {
+            ::tincr::assert { [llength $bel_pins] == 0 } "\[Assertion Error\] Input pin to permutable cell should have no default pin mapping $cell/$cell_pin_name [get_sites -of $cell]"
+            foreach bel_pin_name $input_bel_pin_names {    
+                
+                if { [catch {[set_property LOCK_PINS "{$cell_pin_name:$bel_pin_name}" $cell]} err] == 0 } {
+                    dict lappend pin_map $cell_pin_name $bel_pin_name
+                }
+                reset_property LOCK_PINS $cell
+            }
+        } else { ; # output cell pin
+            ::tincr::assert { [llength $bel_pins] == 1 } "\[Assertion Error\] An output pin should map to exactly one bel pin. $cell/$cell_pin_name [get_sites -of $cell]"
+            set bel_pin_name [lindex [split $bel_pins "/"] end]
+            dict lappend pin_map $cell_pin_name $bel_pin_name
+        }
+        
+        ::tincr::assert { [dict exists $pin_map $cell_pin_name] } "Cell Pin $cell/$cell_pin_name does not map to any bel pins"
+    }
+    
+    write_pin_mappings $cell [list $pin_map] [list "DEFAULT"] $xml_out
+    
+    unplace_cell $cell
+}
+
+## Writes the cell library XML for a macro library cell. This functions is
+#   currently not being used, but may be used in the future when/if macro cells
+#   are supported in RapidSmith
+#   TODO: revisit this if macro cells are supported in RapidSmith.
 proc write_macro_xml {c s fo} {
     puts $fo "        <bel>"
     puts $fo "          <id>"
@@ -278,7 +700,12 @@ proc write_macro_xml {c s fo} {
     puts $fo "        </bel>"
 }
 
+## Creates the cell library XML for a macro library cell
+#   TODO: revisit this function if/when macro cells are supported in RapidSmith
 #
+# @param c Instance of a library cell to process
+# @param s Site location to place the cell on
+# @param fo Output file to print the XML to
 proc process_macrocell {c s fo} {
     set bel_cnt 0
 
@@ -300,275 +727,368 @@ proc process_macrocell {c s fo} {
     }
 }
 
-proc print_port_header {fo type pin_direction} {
-    puts $fo "    <cell>"
-    puts $fo "      <type>$type</type>"
-    puts $fo "      <is_port/>"
-    puts $fo "      <level>LEAF</level>"
-    puts $fo "      <pins>"
-    puts $fo "        <pin>"
-    puts $fo "          <name>PAD</name>"
-    puts $fo "          <direction>$pin_direction</direction>"
-    puts $fo "        </pin>"
-    puts $fo "      </pins>"
+## Writes the cell library XML for a RapidSmith port cell.
+#
+# @param port_type Type of port (either IPORT, OPORT, or IOPORT)
+# @param pin_direction Direction of the cell pin attached to the port 
+# @param port_map Dictionary of site -> bel which this port can be placed
+# @param xml_out File handle to the output XML file
+proc write_port_xml { port_type pin_direction port_map xml_out } {
+    # print the port header
+    puts $xml_out "    <cell>"
+    puts $xml_out "      <type>$port_type</type>"
+    puts $xml_out "      <is_port/>"
+    puts $xml_out "      <level>LEAF</level>"
+    puts $xml_out "      <pins>"
+    puts $xml_out "        <pin>"
+    puts $xml_out "          <name>PAD</name>"
+    puts $xml_out "          <direction>$pin_direction</direction>"
+    puts $xml_out "        </pin>"
+    puts $xml_out "      </pins>"
+    puts $xml_out "      <bels>"
+    
+    # print the bel info for the port
+    dict for {site_type bel_type} $port_map {
+        puts $xml_out "        <bel>"
+        puts $xml_out "          <id>"
+        puts $xml_out "            <primitive_type>$site_type</primitive_type>"
+        puts $xml_out "            <name>$bel_type</name>"
+        puts $xml_out "          </id>"
+        puts $xml_out "        </bel>"        
+    }
+    
+    puts $xml_out "      </bels>"
+    puts $xml_out "    </cell>"
 }
 
-proc write_port_xml { fo lc dict } {
+## Searches through the currently open device, and finds all valid locations where
+#   a RapidSmith port could be placed. Prints XML for each of these ports.
+#
+# @param site_map Dictionary mapping site type to a physical site location
+# @param xml_out File handle to the output XML file
+proc create_port_xml { site_map xml_out } {
 
     puts "Creating port definitions..."
-
-
-    print_port_header $fo "IPORT" "output"
-    puts $fo "      <bels>"
     
-    dict for {type site} $dict {
-	if {[get_property IS_PAD $site] && [get_property NUM_OUTPUTS $site] > 0 } {
-	    foreach b [get_bels -of $site] {
-		if { [get_property TYPE $b] == "PAD" } {
-                    puts $fo "        <bel>"
-                    puts $fo "          <id>"
-                    puts $fo "            <primitive_type>$type</primitive_type>"
-                    puts $fo "            <name>[suffix [get_property NAME $b] "/"]</name>"
-                    puts $fo "          </id>"
-                    puts $fo "        </bel>"
+    set iport_map [dict create]
+    set oport_map [dict create]
+    set ioport_map [dict create]
+    
+    # build the IPORT, OPORT, and IOPORT dictionaries
+    dict for {type site} $site_map {
+    
+        if { [get_property IS_PAD $site] } {
+        
+            set num_inputs [get_property NUM_INPUTS $site]
+            set num_outputs [get_property NUM_OUTPUTS $site]
+            
+            set is_output_pad [expr {$num_inputs > 0} ]
+            set is_input_pad [expr {$num_outputs > 0} ]
+            set is_inout_pad [expr {$num_inputs > 0 && $num_outputs > 0} ]
+            
+            foreach bel [get_bels -of $site -filter {TYPE=="PAD"}] {
+                set bel_name [suffix [get_property NAME $bel] "/"]
+                if {$is_input_pad} {
+                    dict lappend iport_map $type $bel_name
+                }
+                if {$is_output_pad} {
+                    dict lappend oport_map $type $bel_name
+                }
+                if {$is_inout_pad} {
+                    dict lappend ioport_map $type $bel_name
                 }
             }
         }
-        
     }
-    puts $fo "      </bels>"
-    puts $fo "    </cell>"
-
-    print_port_header $fo "OPORT" "input"
-    puts $fo "      <bels>"
     
-    dict for {type site} $dict {
-	if {[get_property IS_PAD $site] && [get_property NUM_INPUTS $site] > 0 } {
-        foreach b [get_bels -of $site] {
-            if { [get_property TYPE $b] == "PAD" } {
-                    puts $fo "        <bel>"
-                    puts $fo "          <id>"
-                    puts $fo "            <primitive_type>$type</primitive_type>"
-                    puts $fo "            <name>[suffix [get_property NAME $b] "/"]</name>"
-                    puts $fo "          </id>"
-                    puts $fo "        </bel>"
-                }
-            }
-        }
-        
-    }
-    puts $fo "      </bels>"
-    puts $fo "    </cell>"
-
-    print_port_header $fo "IOPORT" "inout"
-    puts $fo "      <bels>"
-    
-    dict for {type site} $dict {
-	if {[get_property IS_PAD $site] && [get_property NUM_INPUTS $site] > 0  && [get_property NUM_OUTPUTS $site] > 0 } {
-	    foreach b [get_bels -of $site] {
-		if { [get_property TYPE $b] == "PAD" } {
-                    puts $fo "        <bel>"
-                    puts $fo "          <id>"
-                    puts $fo "            <primitive_type>$type</primitive_type>"
-                    puts $fo "            <name>[suffix [get_property NAME $b] "/"]</name>"
-                    puts $fo "          </id>"
-                    puts $fo "        </bel>"
-                }
-            }
-        }
-        
-    }
-    puts $fo "      </bels>"
-    puts $fo "    </cell>"
+    # write the port information to the xml file
+    write_port_xml "IPORT" "output" $iport_map $xml_out
+    write_port_xml "OPORT" "input" $oport_map $xml_out
+    write_port_xml "IOPORT" "inout" $ioport_map $xml_out    
 }
 
-# Go through and print out all the properties associated with a library cell
-proc print_libcell_properties {fo lc } {
-    set pl [list_property $lc]
-    set lst [list]
-    foreach p $pl  {
-	if { [string first "CONFIG." $p] == 0 } {
-	    set tmp [split $p "."]
-	    if { [llength $tmp] == 2 } {
-		lappend lst $p
-	    }
-	}
+## For each configurable property on the specified library cell, this function writes: <br>
+#   (1) The name of the property <br>
+#   (2) The default value of the property <br>
+#   (3) The max and min value of the property <br>
+#   (4) The possible values of the property <br>
+#   to the specified output file. It also includes any properties included in the
+#   "readonly_properties" list which are not configurable.
+#
+# @param lib_cell Library cell
+# @param xml_out File handle to the output XML file
+proc write_property_xml { lib_cell xml_out } {
 
-	# Add the non-CONFIG properties we care about
-	if { $p == "PRIMITIVE_GROUP" } {
-	    lappend lst $p
-	}
+    set property_map [dict create]
+    # TODO: This should be made a global variable at the top of the file (and set)
+    # And, in the top level genCellLibrary, a list should be passed into the
+    # function that specifies which properties the user wants. The default is what's below.
+    set readonly_properties [list "PRIMITIVE_GROUP"]
+    
+    # create the set of readonly properties to include
+    foreach readonly_prop $readonly_properties {
+        ::struct::set add readonly_properties $readonly_prop
+    }
+        
+    # create the dictionary that maps the configuration properties to the config options (default, min, max, etc.)
+    foreach prop [list_property $lib_cell] {
+        if { [regexp {CONFIG\.([^\.]+)\..*} $prop -> group] } { 
+            dict lappend property_map $group $prop
+        } elseif { [::struct::set contains $readonly_properties $prop ] } {
+            dict set property_map $prop [list]
+        }
     }
     
-    if { [llength $lst] > 0 } {
-	puts $fo "      <libcellproperties>"
-	foreach h $lst {
-	    puts $fo "        <libcellproperty>"
-	    puts $fo "          <name>$h</name>"
-
-	    # For non-CONFIG properties
-	    if { [string first "CONFIG" $h]  == -1 } {
-		puts $fo "          <value>[get_property $h $lc]</value>"
-		puts $fo "          <readonly/>"
-	    }
-	    
-	    foreach p $pl {
-		if { [llength [split $p "."]] == 3 && [string first $h $p] == 0 } {
-		    set tag [lindex [split $p "."] 2]
-		    set tag [string tolower $tag]
-		    puts $fo "          <$tag>[get_property $p $lc]</$tag>"
-		}
-	    }
-	    puts $fo "        </libcellproperty>"
-	}
-	puts $fo "      </libcellproperties>"
+    # print the config map to the xml file (if there exists properties to print)
+    # TODO: is it better to remove the CONFIG part of the property name?
+    if { [dict size $property_map] > 0 } {
+        puts $xml_out "      <libcellproperties>"
+        dict for {config config_options} $property_map {
+            puts $xml_out "        <libcellproperty>"
+            puts $xml_out "          <name>$config</name>"
+            
+            if {[llength $config_options] == 0} { ; # it's a readonly property, can't be configured
+                puts $xml_out "          <readonly/>"
+                puts $xml_out "          <value>[get_property $config $lib_cell]</value>"
+            } else { ; # its a config property      
+                foreach prop $config_options {
+                    set tag [string tolower [lindex [split $prop "."] 2]]
+                    puts $xml_out "          <$tag>[get_property $prop $lib_cell]</$tag>"
+                }
+            }
+            puts $xml_out "        </libcellproperty>"
+        }
+        puts $xml_out "      </libcellproperties>"
     }
 }
 
-#top level function used to create a cell library file used in RapidSmith2
-proc ::tincr::create_xml_cell_library { {part xc7a100t-csg324-3} {filename ""} } {
+## Writes the cell tags to the specified XML file. Cell tags mark
+#   the cell to be unique in some way. These tags include is_lut,
+#   vcc_source, gnd_source, and the primitive level of the cell. 
+#   TODO: Add a permutable_pins tag?
+#
+# @param cell_instance Library cell instance 
+# @param xml_out File handle to the output XML file
+proc write_tag_xml { cell_instance xml_out } {
+    set lib_cell [get_lib_cells -of $cell_instance]
+    set lib_cell_name [get_property NAME $lib_cell]
+    
+    # Tag the type of the library cell
+    puts $xml_out "      <type>$lib_cell_name</type>"
 
-    set part_list [split $part "-"]
+    # Tag LUT cells
+    if { [get_property PRIMITIVE_GROUP $lib_cell] == "LUT" } {
+        puts $xml_out "        <is_lut>"
+        set num_pins [get_property NUM_PINS $lib_cell] 
+        set num [expr {$num_pins - 1}]
+        puts $xml_out "          <num_inputs>$num_pins</num_inputs>"
+        puts $xml_out "        </is_lut>"
+    }
+    
+    # Tag VCC and GND cells
+    if { $lib_cell_name == "VCC" } {
+        puts $xml_out "        <vcc_source/>"
+    }
+    if { $lib_cell_name == "GND" } {
+        puts $xml_out "        <gnd_source/>"
+    }
 
+    # Tag the primitive level (currently unused)
+    puts $xml_out "      <level>[get_property PRIMITIVE_LEVEL $cell_instance]</level>"
+}
+
+## Writes the cell pin information to the specified XML file. 
+#   The name, direction, and type (see {@link get_pin_type}) is
+#   printed for each pin.
+#
+# @param cell_instance Library cell instance
+# @param xml_out File handle to the output XML file
+proc write_pin_xml { cell_instance xml_out } {
+    
+    puts $xml_out "      <pins>"
+
+    #print the cell pin information
+    foreach cell_pin [get_pins -of $cell_instance] {
+        puts $xml_out "        <pin>"
+        puts $xml_out "          <name>[get_property REF_PIN_NAME $cell_pin]</name>"
+
+        set dir [get_property DIRECTION $cell_pin]
+        if { $dir == "IN" } then {
+            puts $xml_out "          <direction>input</direction>"
+        } elseif { $dir == "OUT" }  {
+            puts $xml_out "          <direction>output</direction>"
+        } else {
+            puts $xml_out "          <direction>inout</direction>"
+        }
+        puts $xml_out "          <type>[get_pin_type $cell_pin]</type>"
+
+        puts $xml_out "        </pin>"
+    }
+    puts $xml_out "      </pins>"
+}
+
+## Gets the type of the specified pin according to Vivado. DATA is the
+#   default pin type where no other pin type is specified.
+#   TODO: on each new release of Vivado, verify this function is still correct.
+#
+# @param pin Cell pin
+# @return The type of cell pin
+proc get_pin_type { pin } {
+
+    if { [get_property IS_CLEAR $pin] } {
+        return "CLEAR"
+    } elseif { [get_property IS_CLOCK $pin] } {
+        return "CLOCK"
+    } elseif { [get_property IS_ENABLE $pin] } {
+        return "ENABLE"
+    } elseif { [get_property IS_PRESET $pin] } {
+        return "PRESET"
+    } elseif { [get_property IS_RESET $pin] } {
+        return "RESET"
+    } elseif { [get_property IS_SET $pin] } {
+        return "SET"
+    } elseif { [get_property IS_SETRESET $pin] } {
+        return "SETRESET"
+    } elseif { [get_property IS_WRITE_ENABLE $pin] } {
+        return "WRITE_ENABLE"
+    } else {
+        return "DATA"
+    }
+}
+
+## Generates the cell library XML for the specified cell when it is placed
+#   on each site in the site list (each bel within the site is tested). Currently
+#   ignores macro cells.
+#   TODO: revisit if/when macro cells are supported in RapidSmith.
+#
+# @param cell_instance Library cell instance
+# @param site_type_list List of site types to place cell_instance onto
+# @param site_map Dictionary mapping site types to a physical site location
+# @param alternate_only_sites Set of site types that are only alternate sites
+# @param xml_out File handle to the output XML file
+proc write_bel_placement_xml { cell_instance site_type_list site_map alternate_only_sites xml_out } {
+    
+    set lib_cell_name [get_property REF_NAME $cell_instance]
+    puts $xml_out "      <bels>"
+
+    set net_list [list]
+        
+    #print the placement information
+    foreach site_type $site_type_list {
+        set site [dict get $site_map $site_type]
+
+        set is_alternate 0
+        if { [::struct::set contains $alternate_only_sites $site_type] } {
+            set is_alternate 1
+            set_property MANUAL_ROUTING $site_type $site
+        }
+        
+        if {[get_property PRIMITIVE_LEVEL $cell_instance] == "MACRO"} {
+            # process_macrocell $cell_instance $s $xml_out
+        } else {
+            process_leaf_cell $cell_instance $site $xml_out
+        }
+        
+        if { $is_alternate } {
+            reset_property MANUAL_ROUTING $site
+        }
+    }
+    
+    puts $xml_out "      </bels>"
+}
+
+
+## Creates a cell library XML file that can be used by RapidSmith version 2.0.
+#
+# @param filename Optional parameter to specify the generated cell library name. The default name is
+#           "cellLibrary_part.xml"
+# @param part Xilinx FPGA part to generate a cell library for
+# @param threshold Threshold of configurable pin mappings to compute before quitting. (currently not used
+#           but will be used in the future)
+proc ::tincr::create_xml_cell_library { {part xc7a100t-csg324-3} {filename ""} {threshold 100}} {
+    
+    global config_threshold
+    set config_threshold $threshold
+    
+    # create a valid filename if one is not specified
     if {$filename == ""} {
-        set filename "cellLibrary_[lindex $part_list 0][lindex $part_list 1].xml"
+        set filename "cellLibrary_[get_parts $part].xml"
+    } else { ; # add the xml extension if not specified
+        set filename [::tincr::add_extension ".xml" $filename]
     }
+    
+    set xml_out [open $filename w]
 
-    set fo [open $filename w]
+    # Open empty design to gain access to the Vivado cell library
+    tincr::designs new mydes [get_parts $part]
 
-    #open empty design to gain access to the Vivado cell library
-    create_blank_design_by_part $part
-
-    #find all of the supported library cells in the current part
+    puts "Printing Cells..."
+    
+    # Find all of the supported library cells in the current part
     puts "\nFinding all of the supported cells in the current part..."
-    set supported [get_supported_libcells]
+    set supported_lib_cells [get_supported_libcells]
 
-    #generate a map of lib_cells -> sites that instances of this cell can be placed on
+    # Generate a map of lib_cells -> sites that instances of this cell can be placed on
     puts "Getting a handle to each unique primitive site..."
-    set dict [unique_sites]
+    set unique_sites [create_unique_site_maps]
+    set site_map [lindex $unique_sites 0]
+    set alternate_only_sites [lindex $unique_sites 1]
 
     puts "Finding all valid site placements for each supported cell...\n"
-    set cellsandsites [create_cell_to_site_map $supported $dict]
+    set cell_to_sitetype_map [create_cell_to_site_map $supported_lib_cells $site_map $alternate_only_sites]
 
-    #write the cell library xml file header
-    puts $fo {<?xml version="1.0" encoding="UTF-8"?>}
-    puts $fo "<root>"
-    puts $fo "  <cells>"
+    puts "NETS [get_nets]"
+    
+    # Write the cell library xml file header
+    puts $xml_out {<?xml version="1.0" encoding="UTF-8"?>}
+    puts $xml_out "<root>"
+    puts $xml_out "  <cells>"
 
-    set cnt 0
+    # Create the xml for each valid library cell
+    dict for {lib_cell_name site_type_list} $cell_to_sitetype_map {
+        set lib_cell [get_lib_cells $lib_cell_name -quiet]
+        set cell_instance [create_cell -reference $lib_cell "[string tolower $lib_cell_name]_tmp" -quiet]
 
-    #create the xml for each valid library cell
-    dict for {cname sitenames} $cellsandsites {
-        incr cnt
+        puts "Processing: $lib_cell_name"
 
-        set libcell [get_lib_cells $cname -quiet]
-        set c [create_cell -reference $libcell "brent_$cnt" -quiet]
-        set level [get_property PRIMITIVE_LEVEL $c]
-
-        puts "Processing: $cname"
-
-        puts $fo "    <cell>"
-        set cname [get_property NAME $libcell]
-        puts $fo "      <type>$cname</type>"
-
-        # Mark LUT cells
-	if { [get_property PRIMITIVE_GROUP $libcell] == "LUT" } {
-            puts $fo "        <is_lut>"
-	    set num_pins [get_property NUM_PINS $libcell] 
-	    set num [expr {$num_pins - 1}]
-            puts $fo "          <num_inputs>$num</num_inputs>"
-            puts $fo "        </is_lut>"
-        }
+        puts $xml_out "    <cell>"
         
-        # Mark VCC and GND cells
-        if { $cname == "VCC" } {
-            puts $fo "        <vcc_source/>"
-        }
-        if { $cname == "GND" } {
-            puts $fo "        <gnd_source/>"
-        }
-
+        write_tag_xml $cell_instance $xml_out
+        write_property_xml $lib_cell $xml_out 
+        write_pin_xml $cell_instance $xml_out
         
-	print_libcell_properties $fo $libcell
-
-        puts $fo "      <level>$level</level>"
-        puts $fo "      <pins>"
-
-        #print the cell pin information
-        foreach p [get_pins -of $c] {
-            puts $fo "        <pin>"
-            puts $fo "          <name>[get_property REF_PIN_NAME $p]</name>"
-
-            set dir [get_property DIRECTION $p]
-            if { $dir == "IN" } then {
-                puts $fo "          <direction>input</direction>"
-            } else {
-                puts $fo "          <direction>output</direction>"
-            }
-
-            puts $fo "        </pin>"
-        }
-        puts $fo "      </pins>"
-
-        puts "Sitenames = $sitenames\n"
-        puts $fo "      <bels>"
-
-        #print the placement information
-        foreach sn $sitenames {
-            set s [dict get $dict $sn]
-
-            # We only need to set the type of a site if it is an alternate type only (and not also a default type).
-            # For IOB sites, setting the MANUAL_ROUTING property causes incorrect behavior for example, you can no longer:
-            #  (a) Place cells anywhere on the site
-            #  (b) Query the site for objects such as site pins (this will crash Vivado)
-            # Therefore, the code below was modified to only set the site type if we are not working with an IOB site.
-            # We skip setting slice types as well, because carry4 cells can no longer be placed without an error.
-            # this is not a big deal because we know each slice type will occur as a default type
-            if { [regexp {.*IOB*} $sn] == 0 && [regexp {.*SLICE*} $sn] == 0 } {
-                reset_property MANUAL_ROUTING $s
-                tincr::sites::set_type $s $sn
-            }
-
-            if {$level == "macro"} {
-                # process_macrocell $c $s $fo
-            } else {
-                process_leaf_cell $c $s $fo
-            }
-        }
-        puts $fo "      </bels>"
-        puts $fo "    </cell>"
-        puts $fo ""
+        puts "Sitenames = $site_type_list\n"
+        
+        write_bel_placement_xml $cell_instance $site_type_list $site_map $alternate_only_sites $xml_out
+        
+        puts $xml_out "    </cell>"
+        remove_cell $cell_instance -quiet
     }
 
-    write_port_xml $fo $supported $dict
+    create_port_xml $site_map $xml_out
     
-    puts $fo "  </cells>"
-    puts $fo "</root>"
+    puts $xml_out "  </cells>"
+    puts $xml_out "</root>"
 
-    close $fo
-#    close_design
+    close $xml_out
+    close_design -quiet
 
     puts "CellLibrary \"$filename\" created successfully!"
 }
 
-#test code
+## Function to test the <code>create_xml_cell_library</code> function with assertions
+# and debugging enabled. 
+#
+# @param part Xilinx FPGA part
+proc ::tincr::test_cell_library { {part xc7a100t-csg324-3} } {
+    set ::tincr::enable_assertions 1
+    set ::tincr::debug 0
+    
+    ::tincr::create_xml_cell_library $part "test_cell_library.xml"
+    
+    set ::tincr::enable_assertions 0
+    set ::tincr::debug 0
+}
 
-#set libCell [get_supported_leaf_libcells]
-#set sites [unique_sites
-
-#function call to generate the cell library file
-#createCellLibrary xc7a100t-csg324-3
-
-# Notes
-# ------
-
-# - Currently RapidSmith2 only supports assigning a cell pin to a single bel pin...in Vivado, this is not the case
-#       A macro cell pin can map to several different bel pins. Take a LUTRAM cell for example, the address pins can
-#       be shared across all 4 LUTs, but they all map back to one cell pin for each address pin.
-#       So, in the XML output a different tag is used to represent these (as opposed to the possible tag).
-
-# - I have made a decision...CIN will now only map to CYINIT of the carry 4 in RapidSmith2
-#       This is because only either CIN or CYINIT will be used, not both. We can just include in the
-#       documentation this fact, and if you are designing in rapidSmith2, only map one to the CYINIT
-
-# - an XML template of the cellLibrary has been created, that can be found in the file macro_xml_template.xml
+# global_variables
+set config_threshold 100


### PR DESCRIPTION
## In this commit:

This commit contains several modifications to the cell library generation in TINCR. 
- A large portion of the code was refactored to be more readable. This includes using more descriptive variable and function names, splitting dedicated workloads to their own function, and updating some function implementations.
- Doxygen comments were added to each function in genCellLibrary.tcl.
- Support for configurable pin mappings was added. Currently this is not being used because it is not supported in RapidSmith, but it will be used in the future.  
- Assertions were added throughout the code to document assumptions and help debug. 
- Other updates to the cell library generation such as adding cell pin types and other cell tags.  
