### PR TITLE
Fixed 2 bugs in rs2 checkpoint generation

### DIFF
--- a/tincr/io/design/tincr_checkpoints.tcl
+++ b/tincr/io/design/tincr_checkpoints.tcl
@@ -344,7 +344,7 @@ proc ::tincr::write_placement_rs2 {filename} {
         foreach pin [get_pins -of $cell] {
             append pin_map [get_property REF_PIN_NAME $pin]
             
-            foreach bel_pin [get_bel_pins -of $pin] {
+            foreach bel_pin [get_bel_pins -of $pin -quiet] {
                 
                 # bel_pins follow the naming format: site/bel/pin_name
                 set bel_name_toks [split $bel_pin "/"]
@@ -530,7 +530,7 @@ proc get_static_net_route_string { net } {
         # assuming that the second tile in the tile list is the interconnect tile
         set switchbox_tile [lindex $tiles 1]
         set vcc_route_string [string range $vcc_route_string 3 end-3]
-        set vcc_route_string "( \{ $switchbox_tile/$route_string \} )"
+        set vcc_route_string "( \{ $switchbox_tile/$vcc_route_string \} )"
     }
     
     return $vcc_route_string


### PR DESCRIPTION
These bugs showed up when I did a simple counter example.  They were due to my design having only a single tie-off, something not tested in the test suite.
