### PR TITLE
Reorganized placement.rsc checkpoint file to print port information last

### DIFF
--- a/tincr/io/design/tincr_checkpoints.tcl
+++ b/tincr/io/design/tincr_checkpoints.tcl
@@ -307,18 +307,9 @@ proc ::tincr::write_placement_rs2 {filename} {
     set filename [::tincr::add_extension ".rsc" $filename]
     set txt [open $filename w]
 
-    #right now RS2 doesn't support top-level ports, but we may need this in the future
-    foreach port [get_ports] {
-        if {[get_property PACKAGE_PIN $port] != ""} {
-            puts $txt "PACKAGE_PIN [get_property PACKAGE_PIN $port] [get_ports [get_name $port]]"
-        }
-    }
-
     # TODO: if/when macros are supported, update this function
     set cells [get_cells -hierarchical -filter {PRIMITIVE_LEVEL==LEAF && STATUS!=UNPLACED}]
 
-    # TODO: update this when macros get supported...currently only supports leaf cells
-    # TODO: change this to $cells...we don't need to sort the cells for RapidSmith
     foreach cell $cells {
         
         set site [get_sites -of $cell]
@@ -361,6 +352,13 @@ proc ::tincr::write_placement_rs2 {filename} {
         }
         
         puts $txt "PINMAP [get_name $cell] $pin_map"
+    }
+    
+    # write the port information to the checkpoint file
+    foreach port [get_ports] {
+        if {[get_property PACKAGE_PIN $port] != ""} {
+            puts $txt "PACKAGE_PIN [get_property PACKAGE_PIN $port] [get_ports [get_name $port]]"
+        }
     }
 
     close $txt


### PR DESCRIPTION
In previous versions of `tincr::write_rscp`, the port information was the first thing printed to the `placement.rsc` file. After these port declarations, the cell placement information would be printed. However, this can cause problems when importing the checkpoint into RapidSmith. Take the following example: 
```
...
PACKAGE_PIN clk N15
...
LOC clk_buf N15 IOB33 INBUF_EN
...
```

N15 has a default type of IOB33M. Here are the steps when parsing this file.

1. A new port cell called "clk" is created, and placed on site N15. The site-type is still an IOB33M.
2. Later in the checkpoint, a cell called "clk_buf" is created.
3. Before placing "clk_buf", the site type N15 is changed to an IOB33. 
4. "clk_buf" is placed on N15

However, the port "clk" still thinks it is placed on an IOB33M, which causes other import problems. This pull request fixes this issue by moving the port declarations to the bottom of the `placement.rsc `file so that when they are placed in RapidSmith, the site they are placed on is the correct type.