### PR TITLE
Suppress command output on write_rscp

### DIFF
--- a/tincr/io/design/tincr_checkpoints.tcl
+++ b/tincr/io/design/tincr_checkpoints.tcl
@@ -508,7 +508,7 @@ proc ::tincr::write_routing_rs2 {args} {
     }
     
     # write the physical routing information of each net
-    foreach macro [get_cells -filter {PRIMITIVE_LEVEL==MACRO}] {
+    foreach macro [get_cells -filter {PRIMITIVE_LEVEL==MACRO} -quiet] {
         foreach netname [dict get $internal_net_map [get_property REF_NAME $macro]] {
            lappend nets [get_nets $macro/$netname]    
         }


### PR DESCRIPTION
I forgot to add a "-quiet" option for one of the Vivado commands used in the `write_rscp` function. This pull request fixes that issue.