### PR TITLE
Add internal cell properties to RSCP

### DIFF
--- a/tincr/cad/design/cells.tcl
+++ b/tincr/cad/design/cells.tcl
@@ -476,7 +476,7 @@ proc ::tincr::reset_configuration {cell config_list} {
 # @param cell Vivado cell instance
 # @return A set of reconfigurable properties on that cell  
 #
-proc tincr::get_configurable_properties {cell} {
+proc tincr::cells::get_configurable_properties {cell} {
 
     set config_properties [list]
     

--- a/tincr/cad/design/cells.tcl
+++ b/tincr/cad/design/cells.tcl
@@ -41,7 +41,8 @@ namespace eval ::tincr::cells {
         get_lut_eqn \
         set_lut_eqn \
         get_default_value \
-        reset_configuration
+        reset_configuration \
+        get_configurable_properties
     namespace ensemble create
 }
 
@@ -467,4 +468,23 @@ proc ::tincr::reset_configuration {cell config_list} {
         set default [get_property "CONFIG.$config.DEFAULT" [get_lib_cells -of $cell]]
         set_property $config $default $cell  
     }
+}
+
+## Creates and returns a list of properties on the specified cell object that are configurable.
+#   TODO: cache this information
+#
+# @param cell Vivado cell instance
+# @return A set of reconfigurable properties on that cell  
+#
+proc tincr::get_configurable_properties {cell} {
+
+    set config_properties [list]
+    
+    foreach property [list_property [get_lib_cell -of $cell]] {
+        if { [regexp {CONFIG\.([^\.]+)\.DEFAULT$} $property -> match] } {
+            lappend config_properties $match
+        }
+    }
+    
+    return $config_properties
 }

--- a/tincr/io/design/tincr_checkpoints.tcl
+++ b/tincr/io/design/tincr_checkpoints.tcl
@@ -385,7 +385,7 @@ proc ::tincr::write_placement_rs2 { {filename placement.rsc} }  {
 
     # first, write all internal cell properties that were not included in the EDIF netlist
     foreach cell [get_cells -hierarchical -filter {PRIMITIVE_LEVEL==INTERNAL}] {
-        foreach property [tincr::get_configurable_properties $cell] {
+        foreach property [tincr::cells::get_configurable_properties $cell] {
            
             set value [get_property $property $cell]
             # only print the configurations to the file a value exists, and its not the default value

--- a/tincr/io/design/tincr_checkpoints.tcl
+++ b/tincr/io/design/tincr_checkpoints.tcl
@@ -383,6 +383,19 @@ proc ::tincr::write_placement_rs2 { {filename placement.rsc} }  {
     set filename [::tincr::add_extension ".rsc" $filename]
     set txt [open $filename w]
 
+    # first, write all internal cell properties that were not included in the EDIF netlist
+    foreach cell [get_cells -hierarchical -filter {PRIMITIVE_LEVEL==INTERNAL}] {
+        foreach property [tincr::get_configurable_properties $cell] {
+           
+            set value [get_property $property $cell]
+            # only print the configurations to the file a value exists, and its not the default value
+            # this is the same behavior as EDIF
+            if {$value != "" && $value != [tincr::get_default_value $cell $property]} { 
+                puts $txt "IPROP $cell $property $value"
+            }
+        }
+    }
+    
     # write placement information for leaf and internal cells
     # set cells [get_cells -hierarchical -filter {PRIMITIVE_LEVEL!=MACRO && STATUS!=UNPLACED && BEL!="")}]
     set cells [get_cells -hierarchical -filter {PRIMITIVE_LEVEL!=MACRO && BEL!=""}]


### PR DESCRIPTION
Internal cell configuration properties are not added to the output EDIF file of a RSCP (only the macro cell properties are included). This pull request adds the internal cell property information to the `placement.rsc` file of a RSCP so it can be loaded into RapidSmith.