### PR TITLE
Bel Types

### DIFF
--- a/tincr/io/library/genFamilyInfo.tcl
+++ b/tincr/io/library/genFamilyInfo.tcl
@@ -176,9 +176,10 @@ proc processSite {s type compatible is_alt fo} {
 		
 		#print the bel information 
 		set tmpname [suffix $b "/"]
+		set tmptype [tincr::bels get_type $b]
 		puts $fo "        <bel>"
 		puts $fo "          <name>$tmpname</name>"
-		puts $fo "          <type>$tmpname</type>"
+		puts $fo "          <type>$tmptype</type>"
 
 		#print routethroughs if it is a LUT
 		set siz -1


### PR DESCRIPTION
Currently, genFamilyInfo.tcl records the Bel name instead of the Bel type. This pull request will record the actual Bel type in the familyInfo.xml instead.