### PR TITLE
Tincr write_xdlrc broken: Extra "]" in xdlrc.tcl.

### DIFF
--- a/tincr/io/device/xdlrc.tcl
+++ b/tincr/io/device/xdlrc.tcl
@@ -45,7 +45,7 @@ proc ::tincr::write_xdlrc { args } {
     
     # set a flag if the XDLRC is for series7 devices
     set family [get_property ARCHITECTURE [get_parts $part]]
-    set is_series7 [expr {[string first "7" $family]] != -1 || $family=="zynq"}]
+    set is_series7 [expr {[string first "7" $family] != -1 || $family=="zynq"}]
     
     tincr::run_in_temporary_project -part $part {
         # Declare a semaphore to restrict the number of concurrent processes to "max_processes"


### PR DESCRIPTION
The last commit to master included some changes to tincr/io/device/xdlrc.tcl. An extra closing bracket "]" was inadvertently added on line 48. This resulted in the following error occurring whenever the Tincr command ::tincr::write_xdlrc was used:

> invalid character “]” in expression “…ing first “7” $family]] != -1 || $family==“zy…” 

I have removed the extra ']' so the write_xdlrc command can again be used.