### PR TITLE
Fix for broken write_xdlrc

### DIFF
--- a/tincr/io/device/xdlrc.tcl
+++ b/tincr/io/device/xdlrc.tcl
@@ -19,7 +19,7 @@ namespace eval ::tincr:: {
 }
 
 proc ::tincr::write_xdlrc { args } {
-    # Set defaults for incoming agruments
+    # Set defaults for incoming arguments
     set brief 0
     set primitive_defs 0
     set part [expr {[catch {current_design}] ? "xc7k70tfbg484" : [get_property PART [current_design]]}]
@@ -156,11 +156,19 @@ proc ::tincr::write_xdlrc { args } {
             if {$is_series7 == 0} {
                 lappend site_types "VCC" "GND"
             }
-            
-            puts $outfile "(primitive_defs [llength $site_types]"
+                
+            # Sort site_types alphabetically into sorted_site_types
+            set lst {}
+            dict for {site_type instance} $site_types {
+                # append list elements onto lst
+                lappend lst [list $site_type $instance]
+            }           
+            set sorted_site_types [concat {*}[lsort -dictionary $lst]]
+
+            puts $outfile "(primitive_defs [dict size $sorted_site_types]"
             
             # Append primitive definitions
-            foreach site_type [lsort $site_types] {
+            dict for {site_type instance} $sorted_site_types {
                 set prim_def_file [file join [::tincr::cache::directory_path dict.site_type.src_bel.src_pin.snk_bel.snk_pins] "$site_type.def"]
                 
                 #throw an error if a site type doesn't have a corresponding definition
@@ -177,7 +185,7 @@ proc ::tincr::write_xdlrc { args } {
             }
             
             puts $outfile ")"
-        }
+        } 
         
         puts $outfile "# **************************************************************************"
         puts $outfile "# *                                                                        *"


### PR DESCRIPTION
When trying to re-generate the provided Artix7 device file, this error would occur:
![write_xdlc_error](https://user-images.githubusercontent.com/16548246/30456689-e3a0a740-9961-11e7-9644-037c1fe5436f.png)

It seems the write_xdlrc code was using the SITE_NAME instead of the SITE_TYPE for the given site, which is why the error referenced BSCAN_X0Y0 instead of just BSCAN.

The code in this pull request changes the write_xdlrc function to use some of tcl's dictionary functions when working with a dictionary that maps a SITE_TYPE to a specific site instance (this dictionary is returned from [tincr::sites::unique]). These changes were suggested by @ttown523.

This dictionary is also sorted by key value so the primitive definitions are listed in alphabetical order in the XDLRC.