### PR TITLE
write_xdlrc: Add GND primitive def for non-series7 devices 

### DIFF
--- a/tincr/io/device/xdlrc.tcl
+++ b/tincr/io/device/xdlrc.tcl
@@ -154,7 +154,8 @@ proc ::tincr::write_xdlrc { args } {
             
             # For ultrascale devices add power/ground source sites that aren't explicitly represented in Vivado
             if {$is_series7 == 0} {
-                lappend site_types "VCC" "GND"
+                dict lappend site_types "VCC" "NULL"
+                dict lappend site_types "GND" "NULL"
             }
                 
             # Sort site_types alphabetically into sorted_site_types


### PR DESCRIPTION
The wrong tcl command was being used to add VCC and GND site types to the site type dict that is used to append primitive definitions to the end of a xdlrc file. Instead of both being added, only VCC was added (VCC was the key and GND was the value in the dict). This ultimately resulted in an incorrect XDLRC file.

This PR changes the code by adding both VCC and GND to the dict that is used to append the primitive definitions.