### PR TITLE
Remove duplicate procedures so tincr namespace can be imported

### DIFF
--- a/tincr/cad/util/tcl.tcl
+++ b/tincr/cad/util/tcl.tcl
@@ -17,26 +17,7 @@ namespace ensemble configure dict -map [dict merge [namespace ensemble configure
 
 namespace eval ::tcl {
     namespace export \
-        lremove \
         source_with_args
-}
-
-## Remove an element from a list
-# IMPORTANT NOTE: Don't use this - it has horrible performance
-# TODO Optimize this function
-proc ::tcl::lremove { args } {
-    ::tincr::parse_args {} {all} {} {listVariable value} $args
-    upvar 1 $listVariable var
-    
-    if {$all} {
-        set indices [lsearch -exact -all $var $value]
-        foreach index [lreverse $indices] {
-            set var [lreplace $var $index $index]
-        }
-    } else {
-        set index [lsearch -exact $var $value]
-        set var [lreplace $var $index $index]
-    }
 }
 
 proc ::tcl::source_with_args {file args} {

--- a/tincr/io/device/family_info.tcl
+++ b/tincr/io/device/family_info.tcl
@@ -43,15 +43,6 @@ namespace eval ::tincr:: {
 #       <compatible_type>HPIOB</compatible_type>
 #     </compatible_types>
 
-## Helper function to return the suffix of a split string. For example,
-#   the following call to this function [suffix a/b/c/d "/"] will return "d".
-#
-# @param string String to split
-# @param token Token to split the specified string on
-proc suffix { string token } {
-	return [lindex [split $string $token] end]
-} 
-
 ## Returns a list of routing muxes in the specified site
 #
 # @param site Site object
@@ -179,7 +170,7 @@ proc process_site {site type is_alt compatible_list fileout vsrt_bels_to_add } {
     puts $fileout "      <bels>"
     foreach bel [get_bels -of $site] {
         
-        set bel_name [suffix $bel "/"]
+        set bel_name [tincr::suffix $bel "/"]
         set bel_type [get_property TYPE $bel]
         
         # print the name, type, and routethroughs for the bel
@@ -361,7 +352,7 @@ proc print_inout_pin_corrections {inout_correction_map fileout} {
         foreach pin $inout_pins {
             puts $fileout "        <pin_direction>"
             puts $fileout "          <element>$bel</element>"
-            puts $fileout "          <pin>[suffix $pin "/"]</pin>"
+            puts $fileout "          <pin>[tincr::suffix $pin "/"]</pin>"
             puts $fileout "          <direction>inout</direction>"
             puts $fileout "        </pin_direction>"
         }


### PR DESCRIPTION
This PR removes duplicate procedures so the tincr namespace can be imported into the global namespace. See issue #66.

The `lremove` procedure in `tcl.tcl` is removed and the suffix procedure in `family_info.tcl` is also removed.