### PR TITLE
Revert "XDLRC generation using lists instead of dicts"

### DIFF
--- a/tincr/io/device/xdlrc.tcl
+++ b/tincr/io/device/xdlrc.tcl
@@ -147,20 +147,29 @@ proc ::tincr::write_xdlrc { args } {
         # Newline
         puts "\rPercent complete: 100%"
         
-        set site_types [::tincr::sites get_types]
+        set site_types [::tincr::sites unique]
     
         if {$primitive_defs} {
             # Primitive Definitions
             
             # For ultrascale devices add power/ground source sites that aren't explicitly represented in Vivado
             if {$is_series7 == 0} {
-                lappend site_types "VCC" "GND"
+                dict lappend site_types "VCC" "NULL"
+                dict lappend site_types "GND" "NULL"
             }
                 
-	    puts $outfile "(primitive_defs [llength $site_types]"
+            # Sort site_types alphabetically into sorted_site_types
+            set lst {}
+            dict for {site_type instance} $site_types {
+                # append list elements onto lst
+                lappend lst [list $site_type $instance]
+            }           
+            set sorted_site_types [concat {*}[lsort -dictionary $lst]]
+
+            puts $outfile "(primitive_defs [dict size $sorted_site_types]"
             
             # Append primitive definitions
-            foreach site_type $site_types {
+            dict for {site_type instance} $sorted_site_types {
                 set prim_def_file [file join [::tincr::cache::directory_path dict.site_type.src_bel.src_pin.snk_bel.snk_pins] "$site_type.def"]
                 
                 #throw an error if a site type doesn't have a corresponding definition


### PR DESCRIPTION
Reverts byuccl/tincr#75. The list of site types that was getting returned by sites::get_types was incorrect, resulting in incorrect XDLRC files. I will be looking into why this is the case, but I wanted to revert the change so nobody generates bad XDLRC files.

I apologize for not checking #75 as closely as I should have!