### PR TITLE
Fix for when no speed grade provided to create_xml_device_info

### DIFF
--- a/tincr/cad/util/util.tcl
+++ b/tincr/cad/util/util.tcl
@@ -1576,6 +1576,9 @@ proc ::tincr::print_object_properties { obj } {
 proc ::tincr::remove_speedgrade { partname } {
     set partname_no_speedgrade ""
     regexp {^(x[a-z0-9]+(?:-[a-z0-9]+)?)-.+} $partname -> partname_no_speedgrade
+    if {$partname_no_speedgrade == ""} {
+        set partname_no_speedgrade $partname
+    }
     return $partname_no_speedgrade
 }
 

--- a/tincr/io/device/device_info.tcl
+++ b/tincr/io/device/device_info.tcl
@@ -38,6 +38,9 @@ proc ::tincr::create_xml_device_info { directory partname } {
     # create the output file in the form "device_info_modifiedpartname.xml" 
     # where the partname has been stripped of speedgrade and dash characters 
     set partname_no_speedgrade [tincr::remove_speedgrade $partname] 
+    if {$partname_no_speedgrade == ""} {
+        set partname_no_speedgrade $partname
+    }
     
     set dash_index [string first "-" $partname_no_speedgrade]
     if {$dash_index != -1} {

--- a/tincr/io/device/device_info.tcl
+++ b/tincr/io/device/device_info.tcl
@@ -38,9 +38,6 @@ proc ::tincr::create_xml_device_info { directory partname } {
     # create the output file in the form "device_info_modifiedpartname.xml" 
     # where the partname has been stripped of speedgrade and dash characters 
     set partname_no_speedgrade [tincr::remove_speedgrade $partname] 
-    if {$partname_no_speedgrade == ""} {
-        set partname_no_speedgrade $partname
-    }
     
     set dash_index [string first "-" $partname_no_speedgrade]
     if {$dash_index != -1} {


### PR DESCRIPTION
If no speed grade given then partname ends up as empty.