### PR TITLE
Create nondefault pin mappings based on changed cell properties

### DIFF
--- a/tincr/cad/design/cells.tcl
+++ b/tincr/cad/design/cells.tcl
@@ -557,9 +557,9 @@ proc get_pin_mappings { cell bel } {
 # @return a dictionary of pin mappings
 proc tincr::cells::create_nondefault_pin_mappings { cell bel config_dict } {
     set config_dict [sortDictByKeys $config_dict]
-    dict for {k v} $config_dict {
-        puts "$k:$v"
-    }
+#    dict for {k v} $config_dict {
+#        puts "$k:$v"
+#    }
     
     # attach_nets $cell
             

--- a/tincr/cad/design/cells.tcl
+++ b/tincr/cad/design/cells.tcl
@@ -612,7 +612,7 @@ proc tincr::cells::write_nondefault_pin_mappings { cell bel pin_map config_dict 
     # Also, in the case of multiple mappings, want them in sorted order
     dict for {cp bp} $pin_map {
         foreach bp2 [lsort $bp] {
-            puts $xml_out "          <pin cellPin=\"$cp\" belPin=\"$bp2\" />"
+            puts $xml_out "      <pin cellPin=\"$cp\" belPin=\"$bp2\" />"
         }
     }
     puts $xml_out "    </pins>"


### PR DESCRIPTION
Code has been added to tincr::cells:: that will create an XML file of alternate pin mappings.  The most common occurrence of these is for RAMB and FIFO cells - their write enable pins get moved around based on the shape of the memory configuration.  We know they occur for 5 other less common cells (some DDR kinds of cells).

The usage model is when a previously unseen combination of cell properties for a cell placed on a bel is encountered, you could call this and it will generate the XML of the pin mappings that RapidSmith2 needs.

Inputs to the routine tincr::cells::create_nondefault_pin_mappings include a cell and a bell for it to be placed on, and a list of non-default property values.  The routine will set the indicated property values, place the cell onto the bel, and record the pin mappings that result.  

The routine tincr::cells::write_nondefault_pin_mappings will write these to an XML file that RapidSmith2 can grok.

RapidSmith2 itself maintains a cache of such pinMappings in an XML file and it can be instructed to merge the ones generated here into its cache if they are indeed new.

My tcl coding is crude at best.  @ttown523 and @bradselw - comments and suggestions would be much appreciated to clean this up. :-)