### PR TITLE
Update routing.rsc files to not include intrasite nets with no pins

### DIFF
--- a/tincr/io/design/tincr_checkpoints.tcl
+++ b/tincr/io/design/tincr_checkpoints.tcl
@@ -835,7 +835,7 @@ proc write_net_routing { net_list channel } {
             if {$gnd_net == ""} {
                 set gnd_net $net
             } 
-        } elseif {$status == "INTRASITE"} {
+        } elseif {($status == "INTRASITE") && ([get_property PIN_COUNT $net] != 0)} {
             # mark nets as intrasite in the output routing file
             puts $channel "INTRASITE [get_property NAME $net]"
         } else { ; # regular nets


### PR DESCRIPTION
A newer version of the BYU Edif Tools is going to be added to RapidSmith2's jar directory. A few things have changed in this new version. One change is that the BYU Edif Tools no longer create EdifNet objects for nets that have no associated cell pins. 

In order for the RSCP import process to work correctly in RapidSmith2, RSCPs should not include intrasite nets with no cell pins in the routing.rsc file. This PR fixes this issue.