### PR TITLE
Add XDC files explicitly in order for processing of TCP's

### DIFF
--- a/tincr/io/design/tincr_checkpoints.tcl
+++ b/tincr/io/design/tincr_checkpoints.tcl
@@ -155,7 +155,10 @@ proc ::tincr::read_tcp {args} {
     ::tincr::print_verbose "Reading netlist and constraint files..."
     set edif_runtime [report_runtime "read_edif $q ${filename}/netlist.edf" s]
     set import_fileset [create_fileset -constrset xdc_constraints]
-    add_files -fileset $import_fileset [glob ${filename}/*.xdc]
+    add_files -fileset $import_fileset ${filename}/constraints.xdc 
+    add_files -fileset $import_fileset ${filename}/placement.xdc 
+    add_files -fileset $import_fileset ${filename}/routing.xdc 
+    
     ::tincr::print_verbose "Netlist and constraints added successfully. ($edif_runtime seconds)"
 
     ::tincr::print_verbose "Linking design (this may take awhile)..."


### PR DESCRIPTION
When collecting the list of XDC files to process in tincr::read_tcp a simple 'glob' was used.  This means the files will be processed in the order that glob returns them.  This seems to be in the correct order (placement.xdc before routing.xdc) most of the time but not always.  This fix simply hard codes the order to ensure placement is done before routing.
