### PR TITLE
Namespace conflict: changed get_design calls to get_designs

### DIFF
--- a/tincr/cad/device/parts.tcl
+++ b/tincr/cad/device/parts.tcl
@@ -37,7 +37,7 @@ proc ::tincr::parts::get { args } {
 proc ::tincr::parts::is_series7 { {prt ""} } {
 
     if {$prt == ""} {
-        set prt [get_parts -of [get_design]]
+        set prt [get_parts -of [get_designs]]
     }
     
     set family [get_property ARCHITECTURE $prt]

--- a/tincr/io/design/tincr_checkpoints.tcl
+++ b/tincr/io/design/tincr_checkpoints.tcl
@@ -926,7 +926,7 @@ proc ::tincr::read_tcp_ooc_test {filename} {
         return
     }
 
-    set part [get_property PART [get_design]]
+    set part [get_property PART [get_designs]]
 
     foreach tcp $tcp_files {
         link_design -mode out_of_context -part $part -name $tcp

--- a/tincr/io/device/cell_library.tcl
+++ b/tincr/io/device/cell_library.tcl
@@ -559,7 +559,7 @@ proc create_port_xml { site_map xml_out } {
     puts "Creating port definitions..."
     
     # series7 needs to be processed differently than ultrascale and beyond
-    set arch [get_property ARCHITECTURE [get_parts -of [get_design]]]
+    set arch [get_property ARCHITECTURE [get_parts -of [get_designs]]]
     set is_series7 [tincr::parts::is_series7]
     
     set iport_map [dict create]
@@ -1045,7 +1045,7 @@ proc ::tincr::create_xml_cell_library { {part xc7a100t-csg324-3} {filename ""} {
     puts $xml_out "<root>"
     
     # Add the family tag to the xml file  
-    puts $xml_out "  <family>[string toupper [get_property FAMILY [get_parts -of [get_design]]]]</family>"
+    puts $xml_out "  <family>[string toupper [get_property FAMILY [get_parts -of [get_designs]]]]</family>"
     
     puts $xml_out "  <cells>"
 

--- a/tincr/io/device/device_info.tcl
+++ b/tincr/io/device/device_info.tcl
@@ -77,7 +77,7 @@ proc print_header_device_info {partname_no_speedgrade fileout} {
 #
 # @param fileout XML file handle
 proc print_package_pins { fileout } {
-    set family [get_property ARCHITECTURE [get_parts -of [get_design]]]
+    set family [get_property ARCHITECTURE [get_parts -of [get_designs]]]
     set is_series7 [tincr::parts::is_series7]
     
     puts $fileout "  <package_pins>"


### PR DESCRIPTION
Some calls in Tincr used "get_design" instead of Vivado's "get_designs". The problem with this is that if you import the tincr namespace, "get_design" becomes ambiguous since there is tincr procedure by the name of "get_design_info". See issue #85.

This PR just replaces instances of "get_design" to "get_designs" to fix the problem.