### PR TITLE
Revert "Add RPM/RLOC information to cell library and macro xmls"

### DIFF
--- a/tincr/cad/device/sites.tcl
+++ b/tincr/cad/device/sites.tcl
@@ -27,7 +27,6 @@ namespace eval ::tincr::sites {
         get_types \
         get_type \
         set_type \
-        get_rloc \
         get_routing_muxes \
         get_info \
         compatible_with \
@@ -208,11 +207,6 @@ proc ::tincr::sites::unique { {include_alternate_only_sites 0} } {
             dict set default_sites $default_site_type $site
         }
 
-        # Prefer bonded IOBs if they are available.
-        if { [dict exists $default_sites $default_site_type] && [string match {*IOB*} $default_site_type] && [get_property IS_BONDED $site] == 1 } {
-            dict set default_sites $default_site_type $site
-        }
-
         # add all alternate site types to the alternate site map
         foreach alternate_type [get_property ALTERNATE_SITE_TYPES $site] {
             if {![dict exists $alternates $alternate_type]} {
@@ -366,26 +360,6 @@ proc ::tincr::sites::set_type { sites {type ""} } {
     
     return $sites
 }
-
-## Gets the RLOC for a site, given the site and the origin site.
-#   Assumes the origin site has been correctly determined to be
-#   to the bottom left of the other site.
-#
-# @param origin_site the RPM origin site. Must be to the bottom-left. 
-# @param rloc_site the site to get the RLOC for. 
-#
-# @return The RLOC in the form of "X0Y0"
-proc ::tincr::sites::get_rloc {origin_site rloc_site} {
-    set origin_x [get_property RPM_X $origin_site]
-    set origin_y [get_property RPM_Y $origin_site]
-    set site_x [get_property RPM_X $rloc_site]
-    set site_y [get_property RPM_Y $rloc_site]
-
-    set rloc_x [expr {$site_x - $origin_x}]
-    set rloc_y [expr {$site_y - $origin_y}]
-
-    return "X${rloc_x}Y${rloc_y}"
-} 
 
 # TODO Planned feature: create a "routing mux" Tcl class using this and similar methods to populate it.
 ## Get a list of the routing bels (site muxes) of a site. Unfortunately, site muxes cannot be returned as first-class Tcl objects. No Vivado Tcl command can get handles to the mux objects. In Vivado 2013.2 and earlier, the command internal::get_rbels returns routing bels of a site. The only way to get handles to the routing bels in later versions of Vivado seems to be by clicking on them in the GUI and calling get_selected_objects.

--- a/tincr/cad/util/util.tcl
+++ b/tincr/cad/util/util.tcl
@@ -56,7 +56,6 @@ namespace eval ::tincr {
         organize_by \
         print_verbose \
         assert \
-        prefix \
         suffix \
         set_tcl_display_limit \
         reset_tcl_display_limit
@@ -1271,16 +1270,6 @@ proc ::tincr::add_extension { args } {
     }
     
     return $filename
-}
-
-## Splits the <code>string</code> by <code>token</code>, and returns the first element in the list.
-#  Helper function used to get the type of Vivado elements. For example, the call
-#  <code>prefix "I/am/a/test" "/"</code> will return the string "I."
-#
-# @param string The string to split 
-# @param token The token to split the string on
-proc ::tincr::prefix { string token } {
-    return [lindex [split $string $token] 0]
 }
 
 ## Splits the <code>string</code> by <code>token</code>, and returns the last element in the list.

--- a/tincr/io/design/tincr_checkpoints.tcl
+++ b/tincr/io/design/tincr_checkpoints.tcl
@@ -301,47 +301,6 @@ proc ::tincr::get_pins_to_lock {cell} {
     return $pins_to_lock
 }
 
-## Creates a dictionary that maps a site type to a physical site location for 
-#   the given macro cells. Attempts to find common cases to reduce runtime
-#   and defaults to ::tincr::sites::unique if necessary.
-#
-# @returns 
-#           A list with two elements: <br>
-#           (1) The first element is a dictionary that maps a site type to a site location <br>
-#           (2) A set of site types that are only alternate site types <br>
-proc get_unique_macro_sites {macro_cells} {
-    set default_sites [dict create]
-    set alternate_only_site_set [list]
-    set get_unique_sites 0
-
-    # Find common cases for the macro cells
-    foreach macro $macro_cells {
-        set macro_lib_cell [get_property REF_NAME $macro]
-
-        if {[regexp -nocase {RAM[^B].*} $macro_lib_cell]} {
-            set slicem_sites [get_sites -filter "SITE_TYPE == SLICEM && IS_USED == FALSE"]
-            dict set default_sites "SLICEM" [lindex $slicem_sites 0]
-        } elseif {[string match {*IOB*} $macro_lib_cell]} {
-            set iob_sites [get_sites -filter { SITE_TYPE =~ *IOB* && IS_USED == FALSE } ]
-            foreach iob_site $iob_sites {
-                set default_site_type [get_property SITE_TYPE $iob_site -quiet]
-                if { [dict exists $default_sites $default_site_type] == 0 } {
-                    dict set default_sites $default_site_type $iob_site
-                }
-            }
-        } else {
-            set get_unique_sites 1
-            break
-        }
-    } 
-
-    if {$get_unique_sites} {
-        return [tincr::sites::unique 1]
-    } else {
-        return [list $default_sites $alternate_only_site_set]
-    }
-}
-
 ## Looks for macro cells in the design that aren't in the list of cells returned from
 # the function call "get_lib_cells", and writes the cell library XML for these cells.
 # TODO: add caching to this
@@ -384,25 +343,17 @@ proc ::tincr::write_macros { {filename macros.xml } } {
         }
     }
     
-    if {[llength $macro_cells] > 0 } {
-        set unique_macro_sites [get_unique_macro_sites $macro_cells]
-        set site_map [lindex $unique_macro_sites 0]
-        set alternate_only_sites [lindex $unique_macro_sites 1]
-        set is_series7 [tincr::parts::is_series7]
-
-        set internal_net_map [dict create]
-        # write the XML for new macros
-        foreach macro $macros_to_write {
-            set macro_lib_cell [get_property REF_NAME $macro]
-            set internal_nets [tincr::write_macro_xml $macro_lib_cell $site_map $alternate_only_sites $is_series7 $xml]
-            dict set internal_net_map [get_property REF_NAME $macro] $internal_nets
-        }
-
-        # Create the map of type -> internal netnames for all macros
-        foreach macro $macros_in_design {
-            if { [dict exists $internal_net_map [get_property REF_NAME $macro]] == 0 } {
-                dict set internal_net_map [get_property REF_NAME $macro] [get_internal_macro_nets $macro]
-            }
+    set internal_net_map [dict create]
+    # write the XML for new macros
+    foreach macro $macros_to_write {
+        set internal_nets [tincr::write_macro_xml $macro $xml]
+        dict set internal_net_map [get_property REF_NAME $macro] $internal_nets
+    }
+        
+    # Create the map of type -> internal netnames for all macros
+    foreach macro $macros_in_design {
+        if { [dict exists $internal_net_map [get_property REF_NAME $macro]] == 0 } {
+            dict set internal_net_map [get_property REF_NAME $macro] [get_internal_macro_nets $macro]
         }
     }
     
@@ -444,7 +395,7 @@ proc ::tincr::write_placement_rs2 { {filename placement.rsc} }  {
     }
 
     # write placement information for leaf and internal cells
-    set cells [get_cells -hierarchical -filter {PRIMITIVE_LEVEL!=MACRO && BEL!="" && PRIMITIVE_COUNT==1} -quiet]
+    set cells [get_cells -hierarchical -filter {PRIMITIVE_LEVEL!=MACRO && BEL!="" && PRIMITIVE_COUNT==1}]
 
     # print the placement location and pin-mappings foreach cell in the design
     foreach cell $cells {


### PR DESCRIPTION
Reverts byuccl/tincr#89. Done because some unforeseen complications arose with the additional macro/RPM information. This may be revisited in the future.