### PR TITLE
Support for RM RSCPs and TCPs

### DIFF
--- a/tincr/io/design/pkgIndex.tcl
+++ b/tincr/io/design/pkgIndex.tcl
@@ -2,5 +2,6 @@ if {[info exists ::env(TINCR_PATH)]} {
     package ifneeded tincr.io.design 0.0 {
         source [file join $::env(TINCR_PATH) tincr io design tincr_checkpoints.tcl]
         source [file join $::env(TINCR_PATH) tincr io design rapidsmith.tcl]
+        source [file join $::env(TINCR_PATH) tincr io design static_resources.tcl]
     }
 }

--- a/tincr/io/design/static_resources.tcl
+++ b/tincr/io/design/static_resources.tcl
@@ -1,0 +1,277 @@
+package provide tincr.io.design 0.0
+package require Tcl 8.5
+package require tincr.cad.design 0.0
+package require tincr.cad.device 0.0
+package require tincr.cad.util 0.0
+
+namespace eval ::tincr:: {
+    namespace export \
+    write_static_resources 
+}
+
+## Identifies <b>used</b> site routethroughs present in a list of tiles 
+# (like the tiles of a pblock) and writes these site rouethroughs to the 
+# static.rsc file.
+#
+# @param tiles List of tiles in the reconfigurable region
+# @param channel Output file handle
+# TODO: Optimize this procedure.
+proc write_rp_site_routethroughs { tiles channel } {
+    set site_rts [list]
+    set nets [get_nets -hierarchical]
+
+    # Get all nodes that are in the tiles we care about and that also have nets
+    set nodes [::struct::set intersect [get_nodes -quiet -of_objects $nets] [get_nodes -quiet -of_objects $tiles]]
+    
+    if {[llength $nodes] != 0} {
+
+        # Get the list of nets that those nodes deal with
+        set nets [get_nets -of_objects $nodes]
+        
+        # Get a subset of the PIPs that are within the tiles and are used in nets we care about.
+        set tile_pips [lsort [get_pips -quiet -of_objects $tiles -filter {!IS_TEST_PIP && !IS_EXCLUDED_PIP}]]
+        set net_pips [lsort [get_pips -quiet -of_objects $nets -filter {!IS_TEST_PIP && !IS_EXCLUDED_PIP}]]
+        set pips [::struct::set intersect $tile_pips $net_pips]
+
+        foreach pip $pips {
+            # If the PIP is within the tiles of the pblock
+            set uphill_node [get_nodes -quiet -uphill -of_object $pip]
+            set downhill_node [get_nodes -quiet -downhill -of_object $pip]
+                
+            # A route-through PIP must have an uphill (source) and a downhill (sink) node
+            if {$uphill_node != "" && $downhill_node != ""} {
+                # If PSEUDO, it's a route-through PIP (and not a "real" PIP).
+                if {[get_property IS_PSEUDO $pip]} {
+                    set src_pin [get_site_pins -of_object [get_nodes -uphill -of_object $pip]]
+                    lappend site_rts "[get_sites -of_object $src_pin]"
+                }
+            }
+        }
+    }
+    # print the site routethroughs
+    ::tincr::print_list -header "SITE_RTS" -channel $channel $site_rts
+}
+
+## Finds VCC/GND partition pins (out-of-context ports) in a design and writes them to the routing.rsc file.
+#
+# @param channel File handle to write to
+# TODO: Migrate to tincr_checkpoints.tcl and output in routing.xdc for OOC checkpoints as well?
+proc write_static_part_pins { rp_cell channel } {
+    # Any pins in these lists will be VCC or GND part pins coming into the RP.
+    set vcc_part_pins [list]
+    set gnd_part_pins [list]
+    
+    # Get the vcc part pins
+    set vcc_pins [get_pins -quiet -filter "(PARENT_CELL == [get_property NAME $rp_cell] && HD.ASSIGNED_PPLOCS == \"\" && DIRECTION == \"IN\")" -of_objects [get_nets <const1>]]
+    
+    if {[llength $vcc_pins] != 0} {
+        # Add the names of the partition pins (from the RM's perspective) to the list
+        set vcc_part_pins [get_property REF_PIN_NAME $vcc_pins]
+    }
+    
+    # Get the gnd part pins
+    set gnd_pins [get_pins -quiet -filter "(PARENT_CELL == [get_property NAME $rp_cell] && HD.ASSIGNED_PPLOCS == \"\" && DIRECTION == \"IN\")" -of_objects [get_nets <const0>]]
+    
+    if {[llength $gnd_pins] != 0} {
+        # Add the names of the partition pins (from the RM's perspective) to the list
+        set gnd_part_pins [get_property REF_PIN_NAME $gnd_pins]
+    }
+    
+    ::tincr::print_list -header "VCC_PART_PINS" -channel $channel $vcc_part_pins
+    ::tincr::print_list -header "GND_PART_PINS" -channel $channel $gnd_part_pins
+}
+
+## Searches through the given list of tiles, identifies used PIPs, and
+# writes these used PIPs (as wires) to the PR static export file.
+#
+# @param tiles List of possible tiles with used PIPs (in a reconfigurable region)
+# @param channel Output file handle
+proc write_used_rp_wires { tiles static_nets channel } {
+    set used_wires [list]
+    
+    # Get non partition-pin nets
+    set nets [struct::set difference [get_nets -hierarchical] $static_nets]
+
+    # Get wires from the PIPs. We only want the wires that are at the ends of nodes (not the in-between ones)
+    # First get all nodes that are in the tiles we care about and that also have nets
+    if {[llength $nets] != 0} {
+        set nodes [::struct::set intersect [get_nodes -quiet -of_objects $nets] [get_nodes -quiet -of_objects $tiles]]
+        
+        if {[llength $nodes] != 0} {
+            # Get the list of nets that those nodes deal with
+            set nets [get_nets -of_objects $nodes]
+            
+            # Now, print out the PIPs of each tile using the list of tiles and the list of nets
+            # TODO: Could probably make this faster with a map from tiles -> nets that go through that tile
+            foreach tile $tiles {    
+                set tile_pips [get_pips -quiet -filter "TILE == $tile" -of_objects $nets]
+                foreach pip $tile_pips {
+                    lappend used_wires "[get_wires -of_objects $pip]"
+                }  
+            }
+        }
+    }
+        
+    # print the used wires
+    ::tincr::print_list -header "RESERVED_WIRES" -channel $channel $used_wires
+}
+
+## Prints the partial route strings for the partition pin routes.
+# These route strings only contain the static portion of the nets.
+#
+# @param nets The nets to write route strings for
+# @param channel output channel
+# TODO: Optimize this procedure. 
+proc write_static_routes { nets channel } {	
+	foreach net $nets {
+		if { ($net eq "<const0>") || ($net eq "<const1>") || ($net eq "const0") || ($net eq "const1")} {
+		    continue
+		}	
+	
+		# Get the name(s) of the port(s)
+		# If the net connects to more than one partition pin, there will be multiple associated ports
+	    set ports [get_pins -filter { HD.ASSIGNED_PPLOCS !=  "" } -of_objects [get_nets $net]]
+		
+		set portNames ""
+		foreach port $ports {
+			set portNames "$portNames [string replace $port 0 [string first "/" $port]]"
+		}
+		
+		set route_string "STATIC_RT $net $portNames "
+		
+		# Split report_route_status by lines
+		set lines [split [report_route_status -of_objects $net -return_string] "\n"]
+		
+		foreach line $lines {
+			# Trim spaces, *'s, and p (partition pin marker)
+			set line [string trim $line " *p"]
+			
+			# Remove characters starting from the first '(' to the end of the line
+			# This is the PIP information
+			set start_idx [string first "(" $line] 
+			
+			if {$start_idx == -1} {
+				continue
+			}
+			
+			set line [string replace $line $start_idx end]
+			
+			# Get rid of other extra characters
+			set line [string trim $line " *\["]
+			set line [string map {"p" ""} $line]
+			set line [string map {"*" ""} $line]
+			set line [string map {" " ""} $line]
+			
+			# Check if the first character is a closing curly brace
+			set comparison [string compare -length 1 $line "\}"]
+			
+			if {$comparison == 0} {
+				set line "$line \}"
+				set line [string trimleft $line " \}*\[\]"]
+			}
+			
+			# Check if the first character is an opening curly brace
+			set comparison [string compare -length 1 $line "\{"]
+			if {$comparison == 0} {
+            	set cut_line [string trimleft $line " \{*\[\]"]
+            	# Now check if the next character is a closing curly brace
+            	set comparison [string compare -length 1 $cut_line "\}"]
+                if {$comparison == 0} {
+                	set line "\{ [string range $cut_line 1 end] \}"
+                } else {
+                	set line "\{ [string range $line 1 end]"
+                }
+			}
+			append route_string "$line "
+		}
+		::tincr::print $channel $route_string			
+	}
+}
+
+## Prints the static resources contained within a PR region in a static design.
+#  Searches through a reconfigurable region and writes used resources.
+#  (PIPs, site routethroughs) and partition pin information to the static resources file.
+#  USAGE: tincr::write_static_resources [-quiet] [-verbose] static_dcp prRegion filename
+#   
+#  @param args Argument list shown in the usage statement above. 
+#         The "-quiet " flag can be used to suppress console output. 
+#         The "-verbose" flag can be used to print all messages to the console.
+#         The required static_dcp parameter specifies the path to the DCP of the static design.
+#         The required prRegion parameter specifies the name of the PR region cell.
+#         The required routing_filename parameter specifies the path of the routing.rsc file.
+#         The required static_filename parameter specifies the path of the static.rsc file.
+#TODO: Remove duplicate logic (don't get all nets more than once, etc.)
+proc ::tincr::write_static_resources { args } {
+    set quiet 0
+    set verbose 0
+    set static_dcp ""
+    set prRegion ""
+    set routing_filename ""
+    set static_filename ""
+
+    ::tincr::parse_args {} {quiet verbose} {} {static_dcp prRegion routing_filename static_filename} $args
+    
+    set old_verbose $::tincr::verbose 
+    if {$quiet} {
+        set ::tincr::verbose 0
+    } else {
+        set ::tincr::verbose 1
+    }
+    
+    open_checkpoint $static_dcp
+    set rp_cell [get_cells $prRegion]
+   
+    # Write partition pins (to routing.rsc)
+    set routing_filename [::tincr::add_extension ".rsc" $routing_filename]
+    set routing_channel [open $routing_filename w]
+	set partpin_time [tincr::report_runtime "::tincr::write_part_pins [subst -novariables {$routing_channel}]" s]
+    ::tincr::print_verbose "Partition Pins Done...($partpin_time s)"
+    
+    # Write static partition pins (to routing.rsc)
+    set static_partpin_time [tincr::report_runtime "write_static_part_pins [subst -novariables {$rp_cell $routing_channel}]" s]
+    ::tincr::print_verbose "VCC/GND Partition Pins Done...($static_partpin_time s)"
+    close $routing_channel
+    
+    # create the static resources file
+    set static_filename [::tincr::add_extension ".rsc" $static_filename]
+    set channel_out [open $static_filename w]
+    
+    # Print the static portion of partition pin routes
+    set static_nets [get_nets -of_objects [get_cells -hierarchical -filter { IS_BLACKBOX == "TRUE" } ] ] 
+    set static_route_time [tincr::report_runtime "write_static_routes [subst -novariables {$static_nets $channel_out}]" s]
+    ::tincr::print_verbose "Static Routes Done...($static_route_time s)"
+
+    # It is the user's responsibility to define the pblock for the PR region properly.
+    # No checks are made to ensure it is valid. The partial device file should have the 
+    # same boundaries as this pblock.
+    set pblock [get_pblocks -of_objects $rp_cell]
+    
+    # Get the range of tiles in the pblock
+    set tile_range [split [get_property GRID_RANGES $pblock] ":"]
+    set bott_left_site [get_sites [lindex $tile_range 0]]
+    set top_right_site [get_sites [lindex $tile_range 1]]
+    set bott_left_tile [get_tiles -of_objects $bott_left_site]
+    set top_right_tile [get_tiles -of_objects $top_right_site]
+    
+    # Get row and column ranges
+    set max_row [get_property ROW $bott_left_tile]
+    set min_row [get_property ROW $top_right_tile]
+    set max_col [get_property COLUMN $top_right_tile]
+    set min_col [get_property COLUMN $bott_left_tile]
+
+    # Get used wires.
+    # Get a list of tiles that might have used PIPs (CLB and INT)
+    # Interconnect Tiles (INT_L, INT_R) and CLB Tiles (CLBLM_L, CLBLM_R, CLBLL_L, CLBLL_R) are possible types.
+    set rp_tiles [get_tiles -filter "(ROW >= $min_row && ROW <= $max_row && COLUMN <= $max_col && COLUMN >= $min_col) && (TILE_TYPE == INT_L || TILE_TYPE == INT_R || TILE_TYPE == CLBLM_L || TILE_TYPE == CLBLM_R || TILE_TYPE == CLBLL_L || TILE_TYPE == CLBLL_R) "] 
+    set used_wires_time [tincr::report_runtime "write_used_rp_wires [subst -novariables {$rp_tiles $static_nets $channel_out}]" s]
+    ::tincr::print_verbose "Used Wires Done...($used_wires_time s)"
+   
+    # Get site route-throughs
+    set tiles [get_tiles -filter "(ROW >= $min_row && ROW <= $max_row && COLUMN <= $max_col && COLUMN >= $min_col)"] 
+    set routethrough_time [tincr::report_runtime "write_rp_site_routethroughs [subst -novariables {$tiles $channel_out}]" s]
+    ::tincr::print_verbose "Site route-throughs Done...($routethrough_time s)"
+
+    close_project
+    close $channel_out
+    set ::tincr::verbose $old_verbose
+}

--- a/tincr/io/design/tincr_checkpoints.tcl
+++ b/tincr/io/design/tincr_checkpoints.tcl
@@ -78,7 +78,7 @@ proc ::tincr::write_rscp {args} {
     ::tincr::print_verbose "Placement Done...($placement_runtime s)"
     
     # write routing information
-    set routing_runtime [report_runtime "write_routing_rs2 -global_logic $ooc_flag $internal_net_map ${filename}/routing.rsc" s]
+    set routing_runtime [report_runtime "write_routing_rs2 [subst -novariables {"-global_logic" $ooc_flag $internal_net_map ${filename}/routing.rsc}]" s]
     ::tincr::print_verbose "Routing Done...($routing_runtime s)"
     
     ::tincr::print_verbose "Successfully Created RapidSmith2 Checkpoint!"
@@ -663,7 +663,6 @@ proc ::tincr::write_routing_rs2 {args} {
     
     # select which nets to export (do not get the hierarchical nets)
     if {$global_logic} {
-        puts "global logic"
         set nets [get_nets -quiet]
     } else {
         set nets [get_nets -quiet -filter {TYPE != POWER && TYPE != GROUND}]

--- a/tincr/io/design/tincr_checkpoints.tcl
+++ b/tincr/io/design/tincr_checkpoints.tcl
@@ -142,7 +142,7 @@ proc ::tincr::write_rm_rscp {args} {
     ::tincr::print_verbose "Static Resources Done...($static_runtime s)"
     
     # write routing information
-    set route_runtime [report_runtime "write_routing_rs2 -global_logic $internal_net_map ${filename}/routing.rsc" s]
+    set route_runtime [report_runtime "write_routing_rs2 [subst -novariables {"-global_logic" $internal_net_map ${filename}/routing.rsc}]" s]
     ::tincr::print_verbose "Routing Done...($route_runtime s)"
     
     set total_runtime [expr { $edif_runtime + $macro_time + $place_runtime + $route_runtime + $static_runtime} ]
@@ -207,7 +207,7 @@ proc ::tincr::read_rm_tcp {args} {
         set_property -dict "PACKAGE_PIN $package_pin IOSTANDARD $io_standard" $port
     }
     set end_time [clock clicks -microseconds]
-    set constraints_time [expr $end_time -$start_time]
+    set constraints_time [::tincr::format_time [expr $end_time -$start_time] s]
     ::tincr::print_verbose "Constraints Done...($constraints_time s)"
     
     set total_runtime [expr { $edif_runtime + $place_runtime + $route_runtime + $partpin_runtime + $constraints_time} ]
@@ -663,6 +663,7 @@ proc ::tincr::write_routing_rs2 {args} {
     
     # select which nets to export (do not get the hierarchical nets)
     if {$global_logic} {
+        puts "global logic"
         set nets [get_nets -quiet]
     } else {
         set nets [get_nets -quiet -filter {TYPE != POWER && TYPE != GROUND}]

--- a/tincr/io/design/tincr_checkpoints.tcl
+++ b/tincr/io/design/tincr_checkpoints.tcl
@@ -6,18 +6,16 @@ package require tincr.cad.util 0.0
 
 namespace eval ::tincr:: {
     namespace export \
-        write_tcp \
+        read_rm_tcp \
         read_tcp \
         write_design_info \
-        write_placement_xdc \
-        write_routing_xdc \
         get_design_info \
         get_pins_to_lock\
         write_placement_rs2\
         write_routing_rs2 \
         write_rscp \
-        write_tcp_for_pblock \
-        write_tcp_ooc_test
+        write_rm_rscp \
+        write_part_pins
 }
 
 ## Generates a RSCP. RSCPs are an external representation of a Xilinx design
@@ -26,18 +24,19 @@ namespace eval ::tincr:: {
 #   <a href="https://github.com/byuccl/RapidSmith2/tree/master/doc">https://github.com/byuccl/RapidSmith2/tree/master/doc</a>
 #   and Thomas Townsend's Masters Thesis.
 #
-#   USAGE: tincr::write_rscp [-quiet] [-ooc] [-part partName] filename.rscp
+#   USAGE: tincr::write_rscp [-part partName] [-quiet] [-ooc] filename.rscp
 #
-# @params args Argument list as defined above. The flag "-quiet" 
-#   can be used to suppress console output. The flag "-ooc" needs to be 
-#   set for designs implemented "out-of-context". The "-part partName"  
-#   option is used as the part identifier in the design.info if specified.
+# @params args Argument list as defined above. The "-part partName"  
+#   option is used as the part identifier in the design.info if 
+#   specified.The flag "-quiet" can be used to suppress console output.
+#   The flag "-ooc" needs to be set for designs implemented "out-of-context". 
 #   The filename parameter is the name for the generated RSCP.
 proc ::tincr::write_rscp {args} {
     set quiet 0
     set ooc 0
     set partName ""
-	
+    set ooc_flag ""
+    set mode ""
     ::tincr::parse_args {partName} {quiet ooc} {} {filename} $args
     set filename [::tincr::add_extension ".rscp" $filename]
     file mkdir $filename
@@ -48,44 +47,171 @@ proc ::tincr::write_rscp {args} {
     } else {
         set ::tincr::verbose 1
     }
+    
+    if {$ooc} {
+        set mode "ooc"
+        set ooc_flag "-ooc"
+    }    
        
     ::tincr::print_verbose "Writing RapidSmith2 checkpoint to $filename..."
 
     # generate the design info file
-    write_design_info $ooc -part $partName "${filename}/design.info"
+    write_design_info -mode $mode -part $partName "${filename}/design.info"
     
     # generate the EDIF
-    set start_time [clock clicks -microseconds]
-    write_edif -force "${filename}/netlist.edf"
-    set end_time [clock clicks -microseconds]
-    ::tincr::print_verbose "EDIF Done...([::tincr::format_time [expr $end_time -$start_time] s]s)"
+    set edif_runtime [report_runtime "write_edif -force ${filename}/netlist.edf" s]
+    ::tincr::print_verbose "EDIF Done...($edif_runtime s)"
     
     # generate the macros.xml
     set start_time [clock clicks -microseconds]
     set internal_net_map [write_macros "${filename}/macros.xml"]
     set end_time [clock clicks -microseconds]
-    ::tincr::print_verbose "Macros Done...([::tincr::format_time [expr $end_time -$start_time] s]s)"
+    set macro_time [::tincr::format_time [expr $end_time - $start_time] s]
+    ::tincr::print_verbose "Macros Done...($macro_time s)"
     
     # write design constraints
-    set start_time [clock clicks -microseconds]
-    write_xdc -force "${filename}/constraints.xdc"
-    set end_time [clock clicks -microseconds]
-    ::tincr::print_verbose "XDC Done...([::tincr::format_time [expr $end_time -$start_time] s]s)"
+    set constraints_runtime [report_runtime "write_xdc -force ${filename}/constraints.xdc" s]
+    ::tincr::print_verbose "XDC Done...($constraints_runtime s)"
     
     # write placement information
-    set start_time [clock clicks -microseconds]
-    write_placement_rs2 "${filename}/placement.rsc"
-    set end_time [clock clicks -microseconds]
-    ::tincr::print_verbose "Placement Done...([::tincr::format_time [expr $end_time -$start_time] s]s)"
+    set placement_runtime [report_runtime "write_placement_rs2 ${filename}/placement.rsc" s]
+    ::tincr::print_verbose "Placement Done...($placement_runtime s)"
     
     # write routing information
-    set start_time [clock clicks -microseconds]
-    write_routing_rs2 -global_logic "${filename}/routing.rsc" $internal_net_map
-    set end_time [clock clicks -microseconds]
-    ::tincr::print_verbose "Routing Done...([::tincr::format_time [expr $end_time -$start_time] s]s)"
+    set routing_runtime [report_runtime "write_routing_rs2 -global_logic $ooc_flag $internal_net_map ${filename}/routing.rsc" s]
+    ::tincr::print_verbose "Routing Done...($routing_runtime s)"
     
     ::tincr::print_verbose "Successfully Created RapidSmith2 Checkpoint!"
     set ::tincr::verbose $old_verbose
+}
+
+## Generates an RM RSCP. May be called on an OOC checkpoint only containing the RM
+# TODO: Add support for calling this procedure on a full design. 
+#
+#   USAGE: tincr::write_rm_rscp [-quiet] partialDeviceName staticDCP prRegion filename
+#
+# @params args Argument list as defined above. 
+#         The flag "-quiet"  can be used to suppress console output. 
+#         The required partialDeviceName parameter is used as the part identifier in the design.info.
+#         The required staticDCP parameter specifies the path to the static DCP used to identify static resources.
+#         The required prRegion parameter specifies the name of the PR region cell that should be searched for used resources.
+#         The required filename parameter is the name for the generated RSCP.
+proc ::tincr::write_rm_rscp {args} {
+    set quiet 0
+    set partialDeviceName ""
+    set staticDCP ""
+    set prRegion ""
+    
+    ::tincr::parse_args {} {quiet} {} {partialDeviceName staticDCP prRegion filename} $args
+    set filename [::tincr::add_extension ".rscp" $filename]
+    file mkdir $filename
+
+    set old_verbose $::tincr::verbose 
+    if {$quiet} {
+        set ::tincr::verbose 0
+    } else {
+        set ::tincr::verbose 1
+    }
+       
+    ::tincr::print_verbose "Writing RM RapidSmith2 checkpoint to $filename..."
+
+    # generate the design info file
+    write_design_info -mode "rm" -part $partialDeviceName "${filename}/design.info"
+    
+    # generate the EDIF
+    set edif_runtime [report_runtime "write_edif -force ${filename}/netlist.edf" s]
+    ::tincr::print_verbose "EDIF Done...($edif_runtime s)"
+
+    # generate the macros.xml
+    set start_time [clock clicks -microseconds]
+    set internal_net_map [write_macros "${filename}/macros.xml"]
+    set end_time [clock clicks -microseconds]
+    set macro_time [::tincr::format_time [expr $end_time - $start_time] s]
+    ::tincr::print_verbose "Macros Done...($macro_time s)"
+    
+    # write design constraints
+    set constraints_runtime [report_runtime "write_xdc -force ${filename}/constraints.xdc" s]
+    ::tincr::print_verbose "XDC Done...($constraints_runtime s)"
+    
+    # write placement information
+    set place_runtime [report_runtime "write_placement_rs2 ${filename}/placement.rsc" s]
+    ::tincr::print_verbose "Placement Done...($place_runtime s)"
+    
+    # Write reserved static resources information   
+    set static_runtime [report_runtime "::tincr::write_static_resources $staticDCP $prRegion ${filename}/routing.rsc ${filename}/static.rsc" s]
+    ::tincr::print_verbose "Static Resources Done...($static_runtime s)"
+    
+    # write routing information
+    set route_runtime [report_runtime "write_routing_rs2 -global_logic $internal_net_map ${filename}/routing.rsc" s]
+    ::tincr::print_verbose "Routing Done...($route_runtime s)"
+    
+    set total_runtime [expr { $edif_runtime + $macro_time + $place_runtime + $route_runtime + $static_runtime} ]
+    ::tincr::print_verbose "Successfully Created RM RapidSmith2 Checkpoint ($total_runtime s)"
+    set ::tincr::verbose $old_verbose
+}
+
+
+## Reads a RM (reconfigurable module) TCP design into a corresponding static DCP design in Vivado.
+# TODO: Throw errors if all necessary files are not found.
+# USAGE: tincr::read_rm_tcp [-quiet] [-verbose] staticDCP rp_name filename
+#   
+#   @param args Argument list shown in the usage statement above. The "-quiet " flag
+#       can be used to suppress console output. The "-verbose" flag can be used to print
+#       all messages to the console. This is useful for printing error messages.
+#
+proc ::tincr::read_rm_tcp {args} {
+    set quiet 0
+    set verbose 0
+    set static_dcp ""
+    set rp_name ""
+    ::tincr::parse_args {} {quiet verbose} {} {static_dcp rp_name filename} $args
+    set q "-quiet"
+    set ::tincr::verbose 1
+
+    # quiet has priority over verbose if both are specified
+    if {$quiet} {
+        set ::tincr::verbose 0     
+    } elseif {$verbose} {
+        set q "-verbose"
+    }
+      
+    # Open static design
+    open_checkpoint $static_dcp
+
+    lock_design -level routing
+    # Update the RP blackbox with the RM netlist
+    set edif_runtime [report_runtime "update_design -verbose -cells $rp_name -from_file ${filename}/netlist.edf" s]
+    ::tincr::print_verbose "EDIF Done...($edif_runtime s)"
+
+    # Place and route the RM
+    set place_runtime [report_runtime "read_xdc -cells $rp_name ${filename}/placement.xdc" s]
+    ::tincr::print_verbose "Placement Done...($place_runtime s)"
+
+    set route_runtime [report_runtime "read_xdc -cells $rp_name ${filename}/routing.xdc" s]
+    ::tincr::print_verbose "Routing Done...($route_runtime s)"
+    
+    # Route the partition pin nets
+    set partpin_runtime [report_runtime "read_xdc ${filename}/partpin_routing.xdc" s]
+    ::tincr::print_verbose "Partition Pin Routing Done...($partpin_runtime s)"
+
+    ::tincr::print_verbose "Unlocking the design..."
+    lock_design $q -level placement -unlock
+    
+    # Apply the (I/O) constraints again. For some reason, Vivado needs the port constraints set again, even though they are already set.
+    # Otherwise, it will throw "ERROR: [DRC 23-20] Rule violation (UCIO-1) Unconstrained Logical Port", at bitgen.
+    # Note that just reading in the constraints.xdc at this point doesn't work for some reason.
+    set start_time [clock clicks -microseconds]
+    foreach port [get_ports] {
+        set package_pin [get_property PACKAGE_PIN $port]
+        set io_standard [get_property IOSTANDARD $port]
+        set_property -dict "PACKAGE_PIN $package_pin IOSTANDARD $io_standard" $port
+    }
+    set end_time [clock clicks -microseconds]
+    set constraints_time [expr $end_time -$start_time]
+    ::tincr::print_verbose "Constraints Done...($constraints_time s)"
+    
+    set total_runtime [expr { $edif_runtime + $place_runtime + $route_runtime + $partpin_runtime + $constraints_time} ]
+    ::tincr::print_verbose "RM design importation complete. ($total_runtime seconds)"    
 }
 
 ## Parses a TCP design representation and creates an equivalent design in Vivado. 
@@ -132,16 +258,16 @@ proc ::tincr::read_tcp {args} {
     ::tincr::print_verbose "Reading netlist and constraint files..."
     set edif_runtime [report_runtime "read_edif $q ${filename}/netlist.edf" s]
     set import_fileset [create_fileset -constrset xdc_constraints]
+
     add_files -fileset $import_fileset ${filename}/constraints.xdc 
     add_files -fileset $import_fileset ${filename}/placement.xdc 
     add_files -fileset $import_fileset ${filename}/routing.xdc 
     
     ::tincr::print_verbose "Netlist and constraints added successfully. ($edif_runtime seconds)"
-
     ::tincr::print_verbose "Linking design (this may take awhile)..."
     set link_runtime [report_runtime "link_design $q -mode $link_mode -constrset $import_fileset -part $part" s]
     ::tincr::print_verbose "Design linked successfully. ($link_runtime seconds)"
-    
+
     # complete the route for differential pair nets
     # there is a bug in Vivado where you can't specify the ROUTE string of a net
     # if the source is a port. It will give the error "ERROR: [Designutils 20-949] No driver found on net clock_N[0]"
@@ -177,7 +303,6 @@ proc ::tincr::read_tcp {args} {
     lock_design $q -level placement -unlock
 
     set total_runtime [expr { $edif_runtime + $link_runtime + $diff_time} ]
-    # unlock the design at the end of the import process...do we need to do this?
     ::tincr::print_verbose "Design importation complete. ($total_runtime seconds)"
 }
 
@@ -194,7 +319,7 @@ proc ::tincr::sort_cells_for_export { cells } {
     set ff_5 [list]
 
     # TODO: Eventually, we may have to look through all of the cells
-    #		(internal cells of macros) to support macros.
+    # (internal cells of macros) to support macros.
     foreach cell $cells {
         if {[cells is_placed $cell]} {
             set group [get_property PRIMITIVE_GROUP $cell]
@@ -219,30 +344,29 @@ proc ::tincr::sort_cells_for_export { cells } {
 
 ## Creates the "design.info" file of a RSCP.
 #   
-#   USAGE: tincr::write_design_info [ooc] filename
+#   USAGE: tincr::write_design_info filename -mode mode -part partName
 #
-# @param args Argument list shown in the usage statement above. The optional parameter
-#       "ooc" is used to output the mode of the design. The "-part partName"  
-#   option is used as the part identifier in the design.info if specified.
-#   The filename parameter is the name for the generated design.info.
+# @param args Argument list shown in the usage statement above. The -mode option
+#   is used to output the mode of the design. The -part option is used as the 
+#   part identifier in the design.info. The filename parameter is the name for 
+#   the generated design.info.
 proc ::tincr::write_design_info {args} {
-    set ooc 0
+    set mode ""
     set partName ""
-    ::tincr::parse_args {partName} {} {ooc} {filename} $args
-
+    ::tincr::parse_args {mode partName} {} {} {filename} $args
     set filename [::tincr::add_extension ".info" $filename]
-
     set outfile [open $filename w]
-	
+
     # if no partName is specified, get the part from the design
     if {$partName == ""} {
-	set partName "[get_property PART [current_design]]"
+        set partName "[get_property PART [current_design]]"
     }
 
     puts $outfile "part=$partName"
-    
-    if {$ooc != 0} {
+    if { ($mode eq "ooc") || ($mode eq "out_of_context") } {
         puts $outfile "mode=out_of_context"
+    } elseif { ($mode eq "rm") || ($mode eq "reconfig_module") } {
+        puts $outfile "mode=reconfig_module"
     } else {
         puts $outfile "mode=regular"
     }
@@ -411,7 +535,7 @@ proc ::tincr::write_placement_rs2 { {filename placement.rsc} }  {
         set bel_toks [split [get_property BEL $cell] "."]
         
         # NOTE: We have to do this, because the SITE_TYPE property of sites are not updated correctly
-        #	   when you place cells there. BUFG is an example
+        # when you place cells there. BUFG is an example
         set sitetype [lindex $bel_toks 0]
         set bel [lindex $bel_toks end]
         set tile [get_tile -of $site]
@@ -438,7 +562,6 @@ proc ::tincr::write_placement_rs2 { {filename placement.rsc} }  {
             }
             append pin_map " "
         }
-        
         puts $txt "PINMAP [get_name $cell] $pin_map"
     }
     
@@ -457,7 +580,6 @@ proc ::tincr::write_placement_rs2 { {filename placement.rsc} }  {
             }
         }
     }
-    
     close $txt
 }
 
@@ -508,19 +630,26 @@ proc ::tincr::get_internal_macro_nets {macro} {
 #   - BEL Routethroughs
 #   - Static Source BELs
 #   - Merged VCC/GND net information 
+#  For OOC/RM designs, this file also includes partition pins / ooc ports.
 #
-#   USAGE: tincr::write_routing_rs2 [-global_logic] filename
+#   USAGE: tincr::write_routing_rs2 [-global_logic] [-ooc] internal_net_map filename
 # @param args Argument list shown in the usage statement above. The flag "-global_logic"
-#       is used to include VCC and GND routing. The parameter "filename" is the name
-#       of the file to write the routing information to. The parameter "internal_net_map"
-#       is a list of internal macro nets so the routing information for these nets can be exported.
+#       is used to include VCC and GND routing. The flag "-ooc" is used to include partition pins / ooc ports.
+#       The parameter "internal_net_map" is a list of internal macro nets so the routing information for 
+#       these nets can be exported. The parameter "filename" is the name of the file to write the routing information to. 
 proc ::tincr::write_routing_rs2 {args} {
     set global_logic 0
-    ::tincr::parse_args {} {global_logic} {} {filename internal_net_map} $args
+    set ooc 0
+    ::tincr::parse_args {} {global_logic ooc} {} {internal_net_map filename} $args
 
     # create the routing file
     set filename [::tincr::add_extension ".rsc" $filename]
-    set channel_out [open $filename w]
+    set channel_out [open $filename a+]
+    
+    # write out-of-context hierarchical ports to the file
+    if {$ooc} {
+        ::tincr::write_part_pins $channel_out
+    }
 
     # write the used sites pips to the file
     set used_sites [get_sites -quiet -filter IS_USED] 
@@ -532,14 +661,11 @@ proc ::tincr::write_routing_rs2 {args} {
     # write the static and routethrough lut information to the file
     write_static_and_routethrough_luts $used_sites $channel_out
     
-    # write out-of-context hierarchical ports to the file
-    write_ooc_ports $channel_out
-    
     # select which nets to export (do not get the hierarchical nets)
     if {$global_logic} {
-    	set nets [get_nets -quiet]
+        set nets [get_nets -quiet]
     } else {
-    	set nets [get_nets -quiet -filter {TYPE != POWER && TYPE != GROUND}]
+        set nets [get_nets -quiet -filter {TYPE != POWER && TYPE != GROUND}]
     }
     
     # Add internal hierarchical nets to the list of nets whose routing information should be printed 
@@ -589,7 +715,7 @@ proc write_site_pips { site_list channel } {
 
 ## Searches through the used sites of the design, identifies LUT BELs that are being
 #   used as either a routethrough or static source (always outputs 1 or 0), and writes
-#   identifies these BELs in the routing export file.
+#   these BELs to the routing export file.
 #
 # @param site_list List of <b>used</b> sites in the design
 # @param channel Output file handle
@@ -633,20 +759,49 @@ proc write_static_and_routethrough_luts { site_list channel } {
     ::tincr::print_list -header "LUT_RTS" -channel $channel $routethrough_luts
 }
 
-## Finds all out-of-context ports in a design and adds them to the routing.rsc file. 
-#   This only occurs for designs implemented in out-of-context mode. Out-of-context ports
-#   are those that aren't mapped to PAD BELs, but are partially routed to a specific
+## Finds partition pins (out-of-context ports) in a design and adds them to the routing.rsc file. 
+#   Out-of-context ports are those that aren't mapped to PAD BELs, but are partially routed to a specific
 #   wire in the device. The device wire represents the start/end wire of nets connected
 #   to the port.
 #
 # @param channel File handle to write the ooc ports to
-proc write_ooc_ports {channel} {
-    # for OOC checkpoints with hierarchical ports, print the starting wires for each port
-    # OOC checkpoints has the design property IS_BLOCK set to true
+proc ::tincr::write_part_pins {channel} {
+    # In OOC mode, the partition pins are considered I/O ports in Vivado.
+    # OOC checkpoints have the design property IS_BLOCK set to true
     if {[get_property IS_BLOCK [current_design]]} {
-        # TODO: could change this to have a token of "OOC_PORTS" with a list of ports all on one line, but his is oke for now
         foreach ooc_port [get_ports -filter HD.ASSIGNED_PPLOCS!="" -quiet] {
-             puts $channel "OOC_PORT $ooc_port [string map {" " "/"} [get_property HD.ASSIGNED_PPLOCS $ooc_port]]" 
+            set port_name [get_property NAME [get_ports $ooc_port]]
+            set direction [get_property DIRECTION [get_ports $ooc_port]]
+            
+            # Change the direction to be from the correct perspective
+            set direction [expr {$direction eq "IN" ? "OUT" : "IN"}] 
+            
+            # Get the partition pin's wire
+            set wire_name [string map {" " "/"} [get_property HD.ASSIGNED_PPLOCS $ooc_port]]
+            
+            # Use the wire to get the partition pin's node
+            set node [get_nodes -of_object [get_wires $wire_name]]
+            
+            # Are there cases where the wire is needed instead of the node?
+            puts $channel "PART_PIN $port_name $node $direction" 
+        }
+    } else {
+        # In the PR flow, the partition pins are cell pins in Vivado.
+        foreach part_pin [get_pins -filter HD.ASSIGNED_PPLOCS!="" -quiet] {
+             set pin_name [get_property REF_PIN_NAME [get_pins $part_pin]]
+             set direction [get_property DIRECTION [get_pins $part_pin]]
+             
+             # Change the direction to be from the correct perspective
+             set direction [expr {$direction eq "IN" ? "OUT" : "IN"}] 
+             
+             # Get the partition pin's wire
+             set wire_name [string map {" " "/"} [get_property HD.ASSIGNED_PPLOCS $part_pin]]
+             
+             # Use the wire to get the partition pin's node
+             set node [get_nodes -of_object [get_wires $wire_name]]
+             
+             # Are there cases where the wire is needed instead of the node?
+             puts $channel "PART_PIN $pin_name $node $direction" 
         }
     }
 } 
@@ -796,31 +951,6 @@ proc ::tincr::read_tcp_ooc_test {filename} {
         remove_files *
         close_design
     }
-}
-
-proc ::tincr::write_tcp_ooc_test {filename} {
-
-    file mkdir $filename
-
-    foreach pblock [group_cells_by_clock_region] {
-        set outfile "$filename[file separator][get_property NAME $pblock].tcp"
-
-        set nets [get_internal_nets $pblock]
-        set internal_nets [lindex $nets 0]
-        set external_nets [lindex $nets 1]
-
-        write_tcp_for_pblock $outfile $pblock $internal_nets
-    }
-}
-
-proc ::tincr::write_tcp_for_pblock {filename pblock nets} {
-    set filename [::tincr::add_extension ".tcp" $filename]
-
-    file mkdir $filename
-
-    write_edif -force -pblock $pblock "${filename}"
-    write_placement_xdc -cells [get_cells -of $pblock] "${filename}/placement.xdc"
-    write_routing_xdc -sites [get_sites -of $pblock -filter IS_USED] -nets $nets -global_logic "${filename}/routing.xdc"
 }
 
 # packages the nets of the given pblock by internal nets,


### PR DESCRIPTION
Adds support for reconfigurable module (RM) RSCPs and TCPs. static_resources.tcl contains procedures for generating a static.rsc file, which describes resources a static design has reserved for its own use. Some of these procedures could probably be optimized in the future.

Also removes some deprecated procedures (write_placement_xdc, write_routing_xdc, write_tcp_for_pblock, and write_tcp_ooc_test) from tincr_checkpoints.tcl. 

Also changes tincr_checkpoints' write_ooc_ports procedure to write_part_pins, making it function for both OOC and RM designs.