### PR TITLE
isSeries7 fix

### DIFF
--- a/tincr/cad/device/parts.tcl
+++ b/tincr/cad/device/parts.tcl
@@ -37,7 +37,7 @@ proc ::tincr::parts::get { args } {
 proc ::tincr::parts::is_series7 { {prt ""} } {
 
     if {$prt == ""} {
-        set prt [get_parts -of [get_designs]]
+        set prt [get_parts -of [current_design]]
     }
     
     set family [get_property ARCHITECTURE $prt]


### PR DESCRIPTION
For some devices, this procedure was working incorrectly due to the use of get_designs instead of current_design. With get_designs, more than one designs could be returned (even if only one design was open), causing the rest of the procedure to work incorrectly. Using current_design means only one design is returned instead of a possible list, fixing the problem.