### PR TITLE
Fixed getSitePins for series7

### DIFF
--- a/tincr/cad/design/nets.tcl
+++ b/tincr/cad/design/nets.tcl
@@ -740,6 +740,7 @@ proc ::tincr::nets::recurse_split_route { target var_name path } {
 # @return a list of corrected site pins connected to the net
 proc ::tincr::nets::get_site_pins_of_net { net } {
     set pin_set [list]
+    set is_pad 0
     
     foreach bel_pin [get_bel_pins -of $net -quiet] {
         if {[llength [get_bels -of [get_sites -of $bel_pin]]] == 1} {
@@ -752,6 +753,7 @@ proc ::tincr::nets::get_site_pins_of_net { net } {
                 set site [get_sites -of $site_pin]
                 
                 if {[get_property IS_PAD $site]} {
+                    set is_pad 1
                     set pin_name [lindex [split $site_pin "/"] 1]
                     set iob_name [get_package_pins -of $site]
                     set site_pin "$iob_name/$pin_name"
@@ -762,10 +764,10 @@ proc ::tincr::nets::get_site_pins_of_net { net } {
         }
     }
     
-    # If the site was a pad, check for a missing output site pin. Issues may come up, for example, with 
+    # If the net includes a site pad, check for a missing output site pin. Issues may come up, for example, with 
     # a net that goes from an IOB33S's PADOUT pin to an IOB33M's DIFFI_IN pin. In this case, Vivado does not find
     # the bel pin or the output site pin. It is unknown if this occurs in any other situations.
-    if {[llength $pin_set] == 1} {
+    if {$is_pad == 1 && [llength $pin_set] == 1} {
         set port [get_ports -of_objects $net -quiet]
         set site [get_sites -of_objects $port -quiet]
         foreach site_pin [get_site_pins -of_objects $site -quiet] {

--- a/tincr/cad/design/nets.tcl
+++ b/tincr/cad/design/nets.tcl
@@ -745,7 +745,7 @@ proc ::tincr::nets::get_site_pins_of_net { net } {
     # Bel Pins must be obtained in this manner because get_cell_pins and get_bel_pins sometimes
     # do not return all of the bel pins.
     foreach cell [get_cells -of_objects $net -quiet] {
-        foreach cell_pin [get_pins -of_objects $cell] {
+        foreach cell_pin [get_pins -of_objects $cell -quiet] {
             lappend bel_pins [get_bel_pins -of_objects $cell_pin -quiet]
         }
     }

--- a/tincr/cad/design/nets.tcl
+++ b/tincr/cad/design/nets.tcl
@@ -739,10 +739,18 @@ proc ::tincr::nets::recurse_split_route { target var_name path } {
 # @param net TCL net object
 # @return a list of corrected site pins connected to the net
 proc ::tincr::nets::get_site_pins_of_net { net } {
-    
     set pin_set [list]
+    set bel_pins [list]
     
-    foreach bel_pin [get_bel_pins -of $net -quiet] {
+    # Bel Pins must be obtained in this manner because get_cell_pins and get_bel_pins sometimes
+    # do not return all of the bel pins.
+    foreach cell [get_cells -of_objects $net -quiet] {
+        foreach cell_pin [get_pins -of_objects $cell] {
+            lappend bel_pins [get_bel_pins -of_objects $cell_pin -quiet]
+        }
+    }
+       
+    foreach bel_pin $bel_pins {
         if {[llength [get_bels -of [get_sites -of $bel_pin]]] == 1} {
             # if there is only one bel in the site, the bel pin name will match its corresponding site pin.
             set belPinToks [split $bel_pin "/"]

--- a/tincr/io/design/tincr_checkpoints.tcl
+++ b/tincr/io/design/tincr_checkpoints.tcl
@@ -142,7 +142,7 @@ proc ::tincr::write_rm_rscp {args} {
     ::tincr::print_verbose "Static Resources Done...($static_runtime s)"
     
     # write routing information
-    set route_runtime [report_runtime "write_routing_rs2 [subst -novariables {"-global_logic" $internal_net_map ${filename}/routing.rsc}]" s]
+    set route_runtime [report_runtime "write_routing_rs2 -global_logic -append [subst -novariables {$internal_net_map ${filename}/routing.rsc}]" s]
     ::tincr::print_verbose "Routing Done...($route_runtime s)"
     
     set total_runtime [expr { $edif_runtime + $macro_time + $place_runtime + $route_runtime + $static_runtime} ]
@@ -632,19 +632,27 @@ proc ::tincr::get_internal_macro_nets {macro} {
 #   - Merged VCC/GND net information 
 #  For OOC/RM designs, this file also includes partition pins / ooc ports.
 #
-#   USAGE: tincr::write_routing_rs2 [-global_logic] [-ooc] internal_net_map filename
+#   USAGE: tincr::write_routing_rs2 [-global_logic] [-ooc] [-append] internal_net_map filename
 # @param args Argument list shown in the usage statement above. The flag "-global_logic"
 #       is used to include VCC and GND routing. The flag "-ooc" is used to include partition pins / ooc ports.
+#       The flag "-append" is used to indicate whether the routing.rsc file should be opened as a new file or appended to.
 #       The parameter "internal_net_map" is a list of internal macro nets so the routing information for 
 #       these nets can be exported. The parameter "filename" is the name of the file to write the routing information to. 
 proc ::tincr::write_routing_rs2 {args} {
     set global_logic 0
     set ooc 0
-    ::tincr::parse_args {} {global_logic ooc} {} {internal_net_map filename} $args
+    set append 0
+    ::tincr::parse_args {} {global_logic ooc append} {} {internal_net_map filename} $args
 
     # create the routing file
     set filename [::tincr::add_extension ".rsc" $filename]
-    set channel_out [open $filename a+]
+    set channel_out ""
+    
+    if {$append} {
+        set channel_out [open $filename a+]
+    } else {
+        set channel_out [open $filename w]
+    }
     
     # write out-of-context hierarchical ports to the file
     if {$ooc} {


### PR DESCRIPTION
As explained in the comments of tincr::net::get_site_pins_, the Vivado tcl call to obtain site pins (get_site_pins -of_objects $net) does not work reliably due to a bug with alternate site type pins. When a site is switched to an alternate type, the site pins are not updated in the TCL interface, but they may have changed.

This works for nearly all cases. However, I have found that there are some cases where all of the site pins are still not found. One such case was found with the clock_N[0] net in the superCounter test design. This net connected an IOB33M and IOB33S. Vivado does not include all of the correct bels, bel pins, or cell pins with its tcl calls. I added some code to find the remaining site pin through finding the port, then package pin of the net. I don't know how common this issue comes up, but this at least fixes the problem I observed.

Also made changes so routing.rsc is overwritten when it should be.